### PR TITLE
Skip ClientID check

### DIFF
--- a/options.go
+++ b/options.go
@@ -155,7 +155,8 @@ func (o *Options) Validate() error {
 			return err
 		}
 		o.oidcVerifier = provider.Verifier(&oidc.Config{
-			ClientID: o.ClientID,
+			ClientID:          o.ClientID,
+			SkipClientIDCheck: true,
 		})
 		o.LoginURL = provider.Endpoint().AuthURL
 		o.RedeemURL = provider.Endpoint().TokenURL


### PR DESCRIPTION
There currently seems to be a bug in the `coreos/go-oidc` verify code that means it won't accept a valid token from an authorized party if the `ClientID` isn't the same as the `ClientID` of the original request