### PR TITLE
Reducing cookie split limit 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.9 AS builder
+WORKDIR /go/src/github.com/bitly/oauth2_proxy
+COPY . .
+RUN go get -d -v; \
+    CGO_ENABLED=0 GOOS=linux go build
+
+FROM scratch
+COPY --from=builder /go/src/github.com/bitly/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
+
+ENTRYPOINT ["/bin/oauth2_proxy"]

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
-	flagSet.Var(&whitelistDomains, "whitelist-domains", "allowed domains for redirection after authentication")
+	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	flagSet := flag.NewFlagSet("oauth2_proxy", flag.ExitOnError)
 
 	emailDomains := StringArray{}
+	whitelistDomains := StringArray{}
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
@@ -43,6 +44,7 @@ func main() {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
+	flagSet.Var(&whitelistDomains, "whitelist-domains", "allowed domains for redirection after authentication")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ func main() {
 	flagSet.String("basic-auth-password", "", "the password to set when passing the HTTP Basic Auth header")
 	flagSet.Bool("pass-access-token", false, "pass OAuth access_token to upstream via X-Forwarded-Access-Token header")
 	flagSet.Bool("pass-host-header", true, "pass the request Host Header to upstream")
+	flagSet.Bool("pass-authorization-header", false, "pass the Authorization Header to upstream")
+	flagSet.Bool("set-authorization-header", false, "set Authorization response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&skipAuthRegex, "skip-auth-regex", "bypass authentication for requests path's that match (may be given multiple times)")
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -54,6 +54,7 @@ type OAuthProxy struct {
 	AuthOnlyPath      string
 
 	redirectURL         *url.URL // the url to receive requests at
+	whitelistDomains    []string
 	provider            providers.Provider
 	ProxyPrefix         string
 	SignInMessage       string
@@ -194,6 +195,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		provider:           opts.provider,
 		serveMux:           serveMux,
 		redirectURL:        redirectURL,
+		whitelistDomains:   opts.WhitelistDomains,
 		skipAuthRegex:      opts.SkipAuthRegex,
 		skipAuthPreflight:  opts.SkipAuthPreflight,
 		compiledRegex:      opts.CompiledRegex,
@@ -426,11 +428,38 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 	}
 
 	redirect = req.Form.Get("rd")
-	if redirect == "" || !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
+	if !p.IsValidRedirect(redirect) {
 		redirect = "/"
 	}
 
 	return
+}
+
+func (p *OAuthProxy) IsValidRedirect(redirect string) bool {
+	switch {
+	case strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//"):
+		return true
+	case strings.HasPrefix(redirect, "http://"):
+		redirect = strings.TrimPrefix(redirect, "http://")
+		redirect = strings.Split(redirect, "/")[0]
+		for _, domain := range p.whitelistDomains {
+			if strings.HasSuffix(redirect, domain) {
+				return true
+			}
+		}
+		return false
+	case strings.HasPrefix(redirect, "https://"):
+		redirect = strings.TrimPrefix(redirect, "https://")
+		redirect = strings.Split(redirect, "/")[0]
+		for _, domain := range p.whitelistDomains {
+			if strings.HasSuffix(redirect, domain) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
 }
 
 func (p *OAuthProxy) IsWhitelistedRequest(req *http.Request) (ok bool) {
@@ -562,7 +591,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
+	if !p.IsValidRedirect(redirect) {
 		redirect = "/"
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -439,20 +439,13 @@ func (p *OAuthProxy) IsValidRedirect(redirect string) bool {
 	switch {
 	case strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//"):
 		return true
-	case strings.HasPrefix(redirect, "http://"):
-		redirect = strings.TrimPrefix(redirect, "http://")
-		redirect = strings.Split(redirect, "/")[0]
-		for _, domain := range p.whitelistDomains {
-			if strings.HasSuffix(redirect, domain) {
-				return true
-			}
+	case strings.HasPrefix(redirect, "http://") || strings.HasPrefix(redirect, "https://"):
+		url, err := url.Parse(redirect)
+		if err != nil {
+			return false
 		}
-		return false
-	case strings.HasPrefix(redirect, "https://"):
-		redirect = strings.TrimPrefix(redirect, "https://")
-		redirect = strings.Split(redirect, "/")[0]
 		for _, domain := range p.whitelistDomains {
-			if strings.HasSuffix(redirect, domain) {
+			if (url.Host == domain) || (strings.HasPrefix(domain, ".") && strings.HasSuffix(url.Host, domain)) {
 				return true
 			}
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -260,15 +260,92 @@ func (p *OAuthProxy) redeemCode(host, code string) (s *providers.SessionState, e
 	return
 }
 
-func (p *OAuthProxy) MakeSessionCookie(req *http.Request, value string, expiration time.Duration, now time.Time) *http.Cookie {
+func (p *OAuthProxy) MakeSessionCookie(req *http.Request, value string, expiration time.Duration, now time.Time) []*http.Cookie {
 	if value != "" {
 		value = cookie.SignedValue(p.CookieSeed, p.CookieName, value, now)
-		if len(value) > 4096 {
-			// Cookies cannot be larger than 4kb
-			log.Printf("WARNING - Cookie Size: %d bytes", len(value))
+	}
+	c := p.makeCookie(req, p.CookieName, value, expiration, now)
+	if len(c.Value) > 4096 {
+		return splitCookie(c)
+	}
+	return []*http.Cookie{c}
+}
+
+func copyCookie(c *http.Cookie) *http.Cookie {
+	return &http.Cookie{
+		Name:       c.Name,
+		Value:      c.Value,
+		Path:       c.Path,
+		Domain:     c.Domain,
+		Expires:    c.Expires,
+		RawExpires: c.RawExpires,
+		MaxAge:     c.MaxAge,
+		Secure:     c.Secure,
+		HttpOnly:   c.HttpOnly,
+		Raw:        c.Raw,
+		Unparsed:   c.Unparsed,
+	}
+}
+
+func splitCookie(c *http.Cookie) []*http.Cookie {
+	if len(c.Value) < 3840 {
+		return []*http.Cookie{c}
+	}
+	cookies := []*http.Cookie{}
+	valueBytes := []byte(c.Value)
+	count := 0
+	for len(valueBytes) > 0 {
+		new := copyCookie(c)
+		new.Name = fmt.Sprintf("%s-%d", c.Name, count)
+		count++
+		if len(valueBytes) < 3840 {
+			new.Value = string(valueBytes)
+			valueBytes = []byte{}
+		} else {
+			newValue := valueBytes[:3840]
+			valueBytes = valueBytes[3840:]
+			new.Value = string(newValue)
+		}
+		cookies = append(cookies, new)
+	}
+	return cookies
+}
+
+func joinCookies(cookies []*http.Cookie) (*http.Cookie, error) {
+	if len(cookies) == 0 {
+		return nil, fmt.Errorf("Could not load cookie.")
+	}
+	if len(cookies) == 1 {
+		return cookies[0], nil
+	}
+	c := copyCookie(cookies[0])
+	for i := 1; i < len(cookies); i++ {
+		c.Value += cookies[i].Value
+	}
+	c.Name = strings.TrimRight(c.Name, "-0")
+	return c, nil
+}
+
+func loadCookie(req *http.Request, cookieName string) (*http.Cookie, error) {
+	c, err := req.Cookie(cookieName)
+	if err == nil {
+		return c, nil
+	}
+	cookies := []*http.Cookie{}
+	err = nil
+	count := 0
+	for err == nil {
+		var c *http.Cookie
+		c, err = req.Cookie(fmt.Sprintf("%s-%d", cookieName, count))
+		if err == nil {
+			cookies = append(cookies, c)
+			count++
 		}
 	}
-	return p.makeCookie(req, p.CookieName, value, expiration, now)
+	if len(cookies) == 0 {
+		return nil, fmt.Errorf("Could not find cookie %s", cookieName)
+	}
+	return joinCookies(cookies)
 }
 
 func (p *OAuthProxy) MakeCSRFCookie(req *http.Request, value string, expiration time.Duration, now time.Time) *http.Cookie {
@@ -298,6 +375,7 @@ func (p *OAuthProxy) makeCookie(req *http.Request, name string, value string, ex
 }
 
 func (p *OAuthProxy) ClearCSRFCookie(rw http.ResponseWriter, req *http.Request) {
+
 	http.SetCookie(rw, p.MakeCSRFCookie(req, "", time.Hour*-1, time.Now()))
 }
 
@@ -306,24 +384,28 @@ func (p *OAuthProxy) SetCSRFCookie(rw http.ResponseWriter, req *http.Request, va
 }
 
 func (p *OAuthProxy) ClearSessionCookie(rw http.ResponseWriter, req *http.Request) {
-	clr := p.MakeSessionCookie(req, "", time.Hour*-1, time.Now())
-	http.SetCookie(rw, clr)
+	cookies := p.MakeSessionCookie(req, "", time.Hour*-1, time.Now())
+	for _, clr := range cookies {
+		http.SetCookie(rw, clr)
+	}
 
 	// ugly hack because default domain changed
-	if p.CookieDomain == "" {
-		clr2 := *clr
+	if p.CookieDomain == "" && len(cookies) > 0 {
+		clr2 := *cookies[0]
 		clr2.Domain = req.Host
 		http.SetCookie(rw, &clr2)
 	}
 }
 
 func (p *OAuthProxy) SetSessionCookie(rw http.ResponseWriter, req *http.Request, val string) {
-	http.SetCookie(rw, p.MakeSessionCookie(req, val, p.CookieExpire, time.Now()))
+	for _, c := range p.MakeSessionCookie(req, val, p.CookieExpire, time.Now()) {
+		http.SetCookie(rw, c)
+	}
 }
 
 func (p *OAuthProxy) LoadCookiedSession(req *http.Request) (*providers.SessionState, time.Duration, error) {
 	var age time.Duration
-	c, err := req.Cookie(p.CookieName)
+	c, err := loadCookie(req, p.CookieName)
 	if err != nil {
 		// always http.ErrNoCookie
 		return nil, age, fmt.Errorf("Cookie %q not present", p.CookieName)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -265,7 +265,7 @@ func (p *OAuthProxy) MakeSessionCookie(req *http.Request, value string, expirati
 		value = cookie.SignedValue(p.CookieSeed, p.CookieName, value, now)
 	}
 	c := p.makeCookie(req, p.CookieName, value, expiration, now)
-	if len(c.Value) > 4096 {
+	if len(c.Value) > 3839 {
 		return splitCookie(c)
 	}
 	return []*http.Cookie{c}

--- a/options.go
+++ b/options.go
@@ -32,6 +32,7 @@ type Options struct {
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
+	WhitelistDomains         []string `flag:"whitelist-domains" cfg:"whitelist_domains"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`

--- a/options.go
+++ b/options.go
@@ -32,7 +32,7 @@ type Options struct {
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
-	WhitelistDomains         []string `flag:"whitelist-domains" cfg:"whitelist_domains"`
+	WhitelistDomains         []string `flag:"whitelist-domain" cfg:"whitelist_domains" env:"OAUTH2_PROXY_WHITELIST_DOMAINS"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`

--- a/options.go
+++ b/options.go
@@ -61,6 +61,8 @@ type Options struct {
 	PassUserHeaders       bool     `flag:"pass-user-headers" cfg:"pass_user_headers"`
 	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
 	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
+	SetAuthorization      bool     `flag:"set-authorization-header" cfg:"set_authorization_header"`
+	PassAuthorization     bool     `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 
 	// These options allow for other providers besides Google, with
@@ -111,6 +113,8 @@ func NewOptions() *Options {
 		PassUserHeaders:      true,
 		PassAccessToken:      false,
 		PassHostHeader:       true,
+		SetAuthorization:     false,
+		PassAuthorization:    false,
 		ApprovalPrompt:       "force",
 		RequestLogging:       true,
 		RequestLoggingFormat: defaultRequestLoggingFormat,

--- a/providers/google.go
+++ b/providers/google.go
@@ -141,6 +141,7 @@ func (p *GoogleProvider) Redeem(redirectURL, code string) (s *SessionState, err 
 	}
 	s = &SessionState{
 		AccessToken:  jsonResponse.AccessToken,
+		IdToken:      jsonResponse.IdToken,
 		ExpiresOn:    time.Now().Add(time.Duration(jsonResponse.ExpiresIn) * time.Second).Truncate(time.Second),
 		RefreshToken: jsonResponse.RefreshToken,
 		Email:        email,

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -65,6 +65,7 @@ func (p *OIDCProvider) Redeem(redirectURL, code string) (s *SessionState, err er
 
 	s = &SessionState{
 		AccessToken:  token.AccessToken,
+		IdToken:      rawIDToken,
 		RefreshToken: token.RefreshToken,
 		ExpiresOn:    token.Expiry,
 		Email:        claims.Email,

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -11,6 +11,7 @@ import (
 
 type SessionState struct {
 	AccessToken  string
+	IdToken      string
 	ExpiresOn    time.Time
 	RefreshToken string
 	Email        string

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -30,6 +30,9 @@ func (s *SessionState) String() string {
 	if s.AccessToken != "" {
 		o += " token:true"
 	}
+	if s.IdToken != "" {
+		o += " id_token:true"
+	}
 	if !s.ExpiresOn.IsZero() {
 		o += fmt.Sprintf(" expires:%s", s.ExpiresOn)
 	}
@@ -61,13 +64,20 @@ func (s *SessionState) EncryptedString(c *cookie.Cipher) (string, error) {
 			return "", err
 		}
 	}
+	i := s.IdToken
+	if i != "" {
+		fmt.Printf("Encrytping ID Token")
+		if i, err = c.Encrypt(i); err != nil {
+			return "", err
+		}
+	}
 	r := s.RefreshToken
 	if r != "" {
 		if r, err = c.Encrypt(r); err != nil {
 			return "", err
 		}
 	}
-	return fmt.Sprintf("%s|%s|%d|%s", s.accountInfo(), a, s.ExpiresOn.Unix(), r), nil
+	return fmt.Sprintf("%s|%s|%s|%d|%s", s.accountInfo(), a, i, s.ExpiresOn.Unix(), r), nil
 }
 
 func decodeSessionStatePlain(v string) (s *SessionState, err error) {
@@ -91,8 +101,8 @@ func DecodeSessionState(v string, c *cookie.Cipher) (s *SessionState, err error)
 	}
 
 	chunks := strings.Split(v, "|")
-	if len(chunks) != 4 {
-		err = fmt.Errorf("invalid number of fields (got %d expected 4)", len(chunks))
+	if len(chunks) != 5 {
+		err = fmt.Errorf("invalid number of fields (got %d expected 5)", len(chunks))
 		return
 	}
 
@@ -107,11 +117,17 @@ func DecodeSessionState(v string, c *cookie.Cipher) (s *SessionState, err error)
 		}
 	}
 
-	ts, _ := strconv.Atoi(chunks[2])
+	if chunks[2] != "" {
+		if sessionState.IdToken, err = c.Decrypt(chunks[2]); err != nil {
+			return nil, err
+		}
+	}
+
+	ts, _ := strconv.Atoi(chunks[3])
 	sessionState.ExpiresOn = time.Unix(int64(ts), 0)
 
-	if chunks[3] != "" {
-		if sessionState.RefreshToken, err = c.Decrypt(chunks[3]); err != nil {
+	if chunks[4] != "" {
+		if sessionState.RefreshToken, err = c.Decrypt(chunks[4]); err != nil {
 			return nil, err
 		}
 	}

--- a/providers/session_state_test.go
+++ b/providers/session_state_test.go
@@ -21,12 +21,13 @@ func TestSessionStateSerialization(t *testing.T) {
 	s := &SessionState{
 		Email:        "user@domain.com",
 		AccessToken:  "token1234",
+		IdToken:      "rawtoken1234",
 		ExpiresOn:    time.Now().Add(time.Duration(1) * time.Hour),
 		RefreshToken: "refresh4321",
 	}
 	encoded, err := s.EncodeSessionState(c)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, 3, strings.Count(encoded, "|"))
+	assert.Equal(t, 4, strings.Count(encoded, "|"))
 
 	ss, err := DecodeSessionState(encoded, c)
 	t.Logf("%#v", ss)
@@ -34,6 +35,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	assert.Equal(t, "user", ss.User)
 	assert.Equal(t, s.Email, ss.Email)
 	assert.Equal(t, s.AccessToken, ss.AccessToken)
+	assert.Equal(t, s.IdToken, ss.IdToken)
 	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
 	assert.Equal(t, s.RefreshToken, ss.RefreshToken)
 
@@ -45,6 +47,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	assert.Equal(t, s.Email, ss.Email)
 	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
 	assert.NotEqual(t, s.AccessToken, ss.AccessToken)
+	assert.NotEqual(t, s.IdToken, ss.IdToken)
 	assert.NotEqual(t, s.RefreshToken, ss.RefreshToken)
 }
 
@@ -62,7 +65,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	}
 	encoded, err := s.EncodeSessionState(c)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, 3, strings.Count(encoded, "|"))
+	assert.Equal(t, 4, strings.Count(encoded, "|"))
 
 	ss, err := DecodeSessionState(encoded, c)
 	t.Logf("%#v", ss)


### PR DESCRIPTION
My oauth_proxy cookie length was coming out as 4090. Chrome didn't give any error but I assumed it was going over its max length.

I have to assume that the max length of 4096 includes the variable name.

This change reduces the splitting limit.