### PR TITLE
Audience

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	flagSet.String("google-admin-email", "", "the google admin to impersonate for api calls")
 	flagSet.String("google-service-account-json", "", "the path to the service account json credentials")
 	flagSet.String("client-id", "", "the OAuth Client ID: ie: \"123456.apps.googleusercontent.com\"")
+	flagSet.String("audience-client-id", "", "the OAuth Audience Client ID: ie: \"123456.apps.googleusercontent.com\"")
 	flagSet.String("client-secret", "", "the OAuth Client Secret")
 	flagSet.String("authenticated-emails-file", "", "authenticate against emails via file (one per line)")
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -155,6 +155,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	redirectURL.Path = fmt.Sprintf("%s/callback", opts.ProxyPrefix)
 
 	log.Printf("OAuthProxy configured for %s Client ID: %s", opts.provider.Data().ProviderName, opts.ClientID)
+	log.Printf("OAuthProxy configured for %s Audience Client ID: %s", opts.provider.Data().ProviderName, opts.AudienceClientID)
 	refresh := "disabled"
 	if opts.CookieRefresh != time.Duration(0) {
 		refresh = fmt.Sprintf("after %s", opts.CookieRefresh)

--- a/options.go
+++ b/options.go
@@ -25,6 +25,7 @@ type Options struct {
 	HttpsAddress string `flag:"https-address" cfg:"https_address"`
 	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
+	AudienceClientID     string `flag:"audience-client-id" cfg:"audience_client_id" env:"OAUTH2_PROXY_AUDIENCE_CLIENT_ID"`
 	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
 	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
@@ -153,8 +154,15 @@ func (o *Options) Validate() error {
 		if err != nil {
 			return err
 		}
+
+		ClientID := o.AudienceClientID
+
+		if ClientID == "" {
+			ClientID = o.ClientID
+		}
+
 		o.oidcVerifier = provider.Verifier(&oidc.Config{
-			ClientID: o.ClientID,
+			ClientID: ClientID,
 		})
 		o.LoginURL = provider.Endpoint().AuthURL
 		o.RedeemURL = provider.Endpoint().TokenURL

--- a/options.go
+++ b/options.go
@@ -25,10 +25,11 @@ type Options struct {
 	HttpsAddress string `flag:"https-address" cfg:"https_address"`
 	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
-	AudienceClientID     string `flag:"audience-client-id" cfg:"audience_client_id" env:"OAUTH2_PROXY_AUDIENCE_CLIENT_ID"`
 	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
 	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
+
+	AudienceClientID         string `flag:"audience-client-id" cfg:"audience_client_id" env:"OAUTH2_PROXY_AUDIENCE_CLIENT_ID"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`

--- a/options.go
+++ b/options.go
@@ -29,7 +29,7 @@ type Options struct {
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`
 	TLSKeyFile   string `flag:"tls-key" cfg:"tls_key_file"`
 
-	AudienceClientID         string `flag:"audience-client-id" cfg:"audience_client_id" env:"OAUTH2_PROXY_AUDIENCE_CLIENT_ID"`
+	AudienceClientID string `flag:"audience-client-id" cfg:"audience_client_id" env:"OAUTH2_PROXY_AUDIENCE_CLIENT_ID"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`


### PR DESCRIPTION
This PR adds a flag audience-client-id to allow the passed token to be issued by a different client-id then the client-id used to generate the token.

This is used when configuring the kubernetes-dashboard. The oauth2_proxy in front of the dashboard uses the flags:
    - -client-id=kubernetes-dashboard
    - -audience-client-id=kubernetes
    - -scope=openid profile email groups audience:server:client_id:kubernetes
    - -client-secret=<kubernetes-dashboard-secret>

and in the dex config:
 - id: kubernetes-dashboard
    redirectURIs:
    - 'http://xxx.xxx.xxx.xxx:9090/oauth2/callback'
    name: 'Kubernetes Dashboard'
  - id: kubernetes
    public: true
    name: 'Kubernetes Cluster'
    trustedPeers:
      - kubernetes-dashboard

This allows the kubernetes-dashboard to have a secure redirectURL but still hand kubernetes tokens to the dashboard which in turn hands them to the kube-apiserver that expects all tokens to be issued to the client-id kubernetes.

I have validated this patch works and am prepairing an upstream chart to github.com/helm/charts based on it.