### PR TITLE
Whitelist domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - Implement token refreshing in OIDC provider
   - Split cookies larger than 4k limit into multiple cookies
   - Implement token validation in OIDC provider
+- [#15](https://github.com/pusher/oauth2_proxy/pull/21) WhitelistDomains (@joelspeed)
+  - Add `--whitelist-domain` flag to allow redirection to approved domains after OAuth flow
 - [#21](https://github.com/pusher/oauth2_proxy/pull/21) Docker Improvement (@yaegashi)
   - Move Docker base image from debian to alpine
   - Install ca-certificates in docker image

--- a/README.md
+++ b/README.md
@@ -237,7 +237,10 @@ Usage of oauth2_proxy:
   -upstream value: the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path
   -validate-url string: Access token validation endpoint
   -version: print version string
+  -whitelist-domain: allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)
 ```
+
+Note, when using the `whitelist-domain` option, any domain prefixed with a `.` will allow any subdomain of the specified domain as a valid redirect URL.
 
 See below for provider specific options
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
-	flagSet.Var(&whitelistDomains, "whitelist-domains", "allowed domains for redirection after authentication")
+	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	flagSet := flag.NewFlagSet("oauth2_proxy", flag.ExitOnError)
 
 	emailDomains := StringArray{}
+	whitelistDomains := StringArray{}
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
@@ -45,6 +46,7 @@ func main() {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
+	flagSet.Var(&whitelistDomains, "whitelist-domains", "allowed domains for redirection after authentication")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
-	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication")
+	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -580,20 +580,13 @@ func (p *OAuthProxy) IsValidRedirect(redirect string) bool {
 	switch {
 	case strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//"):
 		return true
-	case strings.HasPrefix(redirect, "http://"):
-		redirect = strings.TrimPrefix(redirect, "http://")
-		redirect = strings.Split(redirect, "/")[0]
-		for _, domain := range p.whitelistDomains {
-			if strings.HasSuffix(redirect, domain) {
-				return true
-			}
+	case strings.HasPrefix(redirect, "http://") || strings.HasPrefix(redirect, "https://"):
+		redirectURL, err := url.Parse(redirect)
+		if err != nil {
+			return false
 		}
-		return false
-	case strings.HasPrefix(redirect, "https://"):
-		redirect = strings.TrimPrefix(redirect, "https://")
-		redirect = strings.Split(redirect, "/")[0]
 		for _, domain := range p.whitelistDomains {
-			if strings.HasSuffix(redirect, domain) {
+			if (redirectURL.Host == domain) || (strings.HasPrefix(domain, ".") && strings.HasSuffix(redirectURL.Host, domain)) {
 				return true
 			}
 		}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -68,6 +68,7 @@ type OAuthProxy struct {
 	AuthOnlyPath      string
 
 	redirectURL         *url.URL // the url to receive requests at
+	whitelistDomains    []string
 	provider            providers.Provider
 	ProxyPrefix         string
 	SignInMessage       string
@@ -220,6 +221,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		provider:           opts.provider,
 		serveMux:           serveMux,
 		redirectURL:        redirectURL,
+		whitelistDomains:   opts.WhitelistDomains,
 		skipAuthRegex:      opts.SkipAuthRegex,
 		skipAuthPreflight:  opts.SkipAuthPreflight,
 		compiledRegex:      opts.CompiledRegex,
@@ -563,7 +565,7 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 	}
 
 	redirect = req.Form.Get("rd")
-	if redirect == "" || !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
+	if !p.IsValidRedirect(redirect) {
 		redirect = req.URL.Path
 		if strings.HasPrefix(redirect, p.ProxyPrefix) {
 			redirect = "/"
@@ -571,6 +573,34 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 	}
 
 	return
+}
+
+// IsValidRedirect checks whether the redirect URL is whitelisted
+func (p *OAuthProxy) IsValidRedirect(redirect string) bool {
+	switch {
+	case strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//"):
+		return true
+	case strings.HasPrefix(redirect, "http://"):
+		redirect = strings.TrimPrefix(redirect, "http://")
+		redirect = strings.Split(redirect, "/")[0]
+		for _, domain := range p.whitelistDomains {
+			if strings.HasSuffix(redirect, domain) {
+				return true
+			}
+		}
+		return false
+	case strings.HasPrefix(redirect, "https://"):
+		redirect = strings.TrimPrefix(redirect, "https://")
+		redirect = strings.Split(redirect, "/")[0]
+		for _, domain := range p.whitelistDomains {
+			if strings.HasSuffix(redirect, domain) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
 }
 
 // IsWhitelistedRequest is used to check if auth should be skipped for this request
@@ -709,7 +739,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
+	if !p.IsValidRedirect(redirect) {
 		redirect = "/"
 	}
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -93,6 +93,44 @@ func TestRobotsTxt(t *testing.T) {
 	assert.Equal(t, "User-agent: *\nDisallow: /", rw.Body.String())
 }
 
+func TestIsValidRedirect(t *testing.T) {
+	opts := NewOptions()
+	opts.ClientID = "bazquux"
+	opts.ClientSecret = "foobar"
+	opts.CookieSecret = "xyzzyplugh"
+	opts.WhitelistDomains = []string{"foo.bar"}
+	opts.Validate()
+
+	proxy := NewOAuthProxy(opts, func(string) bool { return true })
+
+	noRD := proxy.IsValidRedirect("")
+	assert.Equal(t, false, noRD)
+
+	singleSlash := proxy.IsValidRedirect("/redirect")
+	assert.Equal(t, true, singleSlash)
+
+	doubleSlash := proxy.IsValidRedirect("//redirect")
+	assert.Equal(t, false, doubleSlash)
+
+	validHTTP := proxy.IsValidRedirect("http://baz.foo.bar/redirect")
+	assert.Equal(t, true, validHTTP)
+
+	validHTTPS := proxy.IsValidRedirect("https://baz.foo.bar/redirect")
+	assert.Equal(t, true, validHTTPS)
+
+	invalidHTTP1 := proxy.IsValidRedirect("http://foo.bar.evil.corp/redirect")
+	assert.Equal(t, false, invalidHTTP1)
+
+	invalidHTTPS1 := proxy.IsValidRedirect("https://foo.bar.evil.corp/redirect")
+	assert.Equal(t, false, invalidHTTPS1)
+
+	invalidHTTP2 := proxy.IsValidRedirect("http://evil.corp/redirect?rd=foo.bar")
+	assert.Equal(t, false, invalidHTTP2)
+
+	invalidHTTPS2 := proxy.IsValidRedirect("https://evil.corp/redirect?rd=foo.bar")
+	assert.Equal(t, false, invalidHTTPS2)
+}
+
 type TestProvider struct {
 	*providers.ProviderData
 	EmailAddress string

--- a/options.go
+++ b/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
+	WhitelistDomains         []string `flag:"whitelist-domains" cfg:"whitelist_domains"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`

--- a/options.go
+++ b/options.go
@@ -33,7 +33,7 @@ type Options struct {
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant"`
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains"`
-	WhitelistDomains         []string `flag:"whitelist-domains" cfg:"whitelist_domains"`
+	WhitelistDomains         []string `flag:"whitelist-domain" cfg:"whitelist_domains" env:"OAUTH2_PROXY_WHITELIST_DOMAINS"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org"`
 	GitHubTeam               string   `flag:"github-team" cfg:"github_team"`
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group"`


### PR DESCRIPTION
This PR replaces: https://github.com/bitly/oauth2_proxy/pull/464
Fixes: #12 

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a `whitelist-domain` flag that can be used to whitelist a set of domains for the redirect parameter in the authentication request

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I wrote this to fix #399.

It allows you to set a whitelist of redirect domains which is useful when you wish to run 1 copy of the oauth2_proxy but protect multiple different endpoints (used particularly in the nginx auth_request mode)


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been running for us in production for nearly a year.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
