### PR TITLE
build: use go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 go:
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
 install:
   # Fetch dependencies
-  - wget -O dep https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64
+  - wget -O dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
   - chmod +x dep
   - mv dep $GOPATH/bin/dep
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM golang:1.10 AS builder
+FROM golang:1.11-stretch AS builder
 WORKDIR /go/src/github.com/pusher/oauth2_proxy
 COPY . .
 
 # Fetch dependencies
-RUN go get -u github.com/golang/dep/cmd/dep
+RUN wget -O dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
+RUN chmod +x dep
+RUN mv dep $GOPATH/bin/dep
 RUN dep ensure --vendor-only
 
 # Build image

--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ check_for() {
 check_go_version() {
   echo -n "Checking go version... "
   GO_VERSION=$(${tools[go]} version | ${tools[awk]} '{where = match($0, /[0-9]\.[0-9]+\.[0-9]*/); if (where != 0) print substr($0, RSTART, RLENGTH)}')
-  vercomp $GO_VERSION 1.9
+  vercomp $GO_VERSION 1.10
   case $? in
     0) ;&
     1)
@@ -91,7 +91,7 @@ check_go_version() {
       ;;
     2)
       printf "${RED}"
-      echo "$GO_VERSION < 1.9"
+      echo "$GO_VERSION < 1.10"
       exit 1
       ;;
   esac


### PR DESCRIPTION
## Description
- Upgraded Go version for Docker and Travis builds to 1.11.
- Removed Go version 1.9 from Travis CI environment.
- Unify `dep` version 0.5.0 across Docker and Travis CI environments.

## Motivation and Context

- Go 1.11 is the current minor release therefore this upgrade is recommended.

## How Has This Been Tested?

- Successfully built locally.
- Successfully built on Travis CI environment.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
