### PR TITLE
Docker improvement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile.dev

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ _testmain.go
 
 # Editor swap/temp files
 .*.swp
+
+# Dockerfile.dev is ignored by both git and docker
+# for faster development cycle of docker build
+# cp Dockerfile Dockerfile.dev
+# vi Dockerfile.dev
+# docker build -f Dockerfile.dev .
+Dockerfile.dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,22 @@
 FROM golang:1.11-stretch AS builder
-WORKDIR /go/src/github.com/pusher/oauth2_proxy
+
+# Download tools
+RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
+RUN chmod +x $GOPATH/bin/dep
+
+# Copy sources
+WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
 COPY . .
 
 # Fetch dependencies
-RUN wget -O dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
-RUN chmod +x dep
-RUN mv dep $GOPATH/bin/dep
 RUN dep ensure --vendor-only
 
-# Build image
-RUN ./configure && make clean oauth2_proxy
+# Build binary
+RUN ./configure && make build
 
-# Copy binary to debian
-FROM debian:stretch
+# Copy binary to alpine
+FROM alpine:3.8
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 
 ENTRYPOINT ["/bin/oauth2_proxy"]

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ dep:
 build: clean $(BINARY)
 
 $(BINARY):
-	$(GO) build -ldflags="-X main.VERSION=${VERSION}" -o $(BINARY) github.com/pusher/oauth2_proxy
+	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X main.VERSION=${VERSION}" -o $@ github.com/pusher/oauth2_proxy
 
 .PHONY: test
 test: dep lint


### PR DESCRIPTION
## Description

Update Makefile and Dockerfile to build a static binary and get a much smaller footprint with alpine image.  It also includes CA certificates needed for practical use.

Add Dockerfile.dev in .gitignore and .dockerignore.  It's to utilize cached build steps on Dockerfile development.

Optimize ordering of build steps in Dockerfile to avoid needless downloads.

## Motivation and Context

This PR improves Docker building facilities to achieve a faster development cycle and a smaller footprint image for practical use.

## How Has This Been Tested?

You can get build results very fast by utilizing cached build steps on development using Dockerfile.dev.

```console
$ cp Dockerfile Dockerfile.dev
$ vi Dockerfile.dev
$ docker build -f Dockerfile.dev .
```

You can get 17.1MB in size by building this image.

```console
$ docker images oauth2_proxy:latest 
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
oauth2_proxy        latest              8d7d2c24c5bd        14 seconds ago      17.1MB
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
