### PR TITLE
Implemented flushing interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - [#21](https://github.com/pusher/oauth2_proxy/pull/21) Docker Improvement (@yaegashi)
   - Move Docker base image from debian to alpine
   - Install ca-certificates in docker image
+- [#23](https://github.com/pusher/oauth2_proxy/pull/21) Flushed streaming responses
+  - Long-running upstream responses will get flushed every <timeperiod> (1 second by default)
 
 # v3.0.0
 

--- a/logging_handler.go
+++ b/logging_handler.go
@@ -76,6 +76,12 @@ func (l *responseLogger) Size() int {
 	return l.size
 }
 
+func (l *responseLogger) Flush() {
+	if flusher, ok := l.w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 // logMessageData is the container for all values that are available as variables in the request logging format.
 // All values are pre-formatted strings so it is easy to use them in the format string.
 type logMessageData struct {

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ func main() {
 	flagSet.Bool("skip-provider-button", false, "will skip sign-in-page to directly reach the next step: oauth/start")
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
+	flagSet.Duration("flush-interval", time.Duration(1)*time.Second, "period between response flushing when streaming responses")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -110,8 +110,10 @@ func (u *UpstreamProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // NewReverseProxy creates a new reverse proxy for proxying requests to upstream
 // servers
-func NewReverseProxy(target *url.URL) (proxy *httputil.ReverseProxy) {
-	return httputil.NewSingleHostReverseProxy(target)
+func NewReverseProxy(target *url.URL, flushInterval time.Duration) (proxy *httputil.ReverseProxy) {
+	proxy = httputil.NewSingleHostReverseProxy(target)
+	proxy.FlushInterval = flushInterval
+	return proxy
 }
 
 func setProxyUpstreamHostHeader(proxy *httputil.ReverseProxy, target *url.URL) {
@@ -154,7 +156,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		case httpScheme, httpsScheme:
 			u.Path = ""
 			log.Printf("mapping path %q => upstream %q", path, u)
-			proxy := NewReverseProxy(u)
+			proxy := NewReverseProxy(u, opts.FlushInterval)
 			if !opts.PassHostHeader {
 				setProxyUpstreamHostHeader(proxy, u)
 			} else {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -38,7 +38,7 @@ func TestNewReverseProxy(t *testing.T) {
 	backendHost := net.JoinHostPort(backendHostname, backendPort)
 	proxyURL, _ := url.Parse(backendURL.Scheme + "://" + backendHost + "/")
 
-	proxyHandler := NewReverseProxy(proxyURL)
+	proxyHandler := NewReverseProxy(proxyURL, time.Second)
 	setProxyUpstreamHostHeader(proxyHandler, proxyURL)
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()
@@ -60,7 +60,7 @@ func TestEncodedSlashes(t *testing.T) {
 	defer backend.Close()
 
 	b, _ := url.Parse(backend.URL)
-	proxyHandler := NewReverseProxy(b)
+	proxyHandler := NewReverseProxy(b, time.Second)
 	setProxyDirector(proxyHandler)
 	frontend := httptest.NewServer(proxyHandler)
 	defer frontend.Close()

--- a/options.go
+++ b/options.go
@@ -51,19 +51,19 @@ type Options struct {
 	CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	CookieHTTPOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 
-	Upstreams             []string `flag:"upstream" cfg:"upstreams"`
-	SkipAuthRegex         []string `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
-	PassBasicAuth         bool     `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
-	BasicAuthPassword     string   `flag:"basic-auth-password" cfg:"basic_auth_password"`
-	PassAccessToken       bool     `flag:"pass-access-token" cfg:"pass_access_token"`
-	PassHostHeader        bool     `flag:"pass-host-header" cfg:"pass_host_header"`
-	SkipProviderButton    bool     `flag:"skip-provider-button" cfg:"skip_provider_button"`
-	PassUserHeaders       bool     `flag:"pass-user-headers" cfg:"pass_user_headers"`
-	SSLInsecureSkipVerify bool     `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
-	SetXAuthRequest       bool     `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
-	SetAuthorization      bool     `flag:"set-authorization-header" cfg:"set_authorization_header"`
-	PassAuthorization     bool     `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
-	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
+	Upstreams             []string      `flag:"upstream" cfg:"upstreams"`
+	SkipAuthRegex         []string      `flag:"skip-auth-regex" cfg:"skip_auth_regex"`
+	PassBasicAuth         bool          `flag:"pass-basic-auth" cfg:"pass_basic_auth"`
+	BasicAuthPassword     string        `flag:"basic-auth-password" cfg:"basic_auth_password"`
+	PassAccessToken       bool          `flag:"pass-access-token" cfg:"pass_access_token"`
+	PassHostHeader        bool          `flag:"pass-host-header" cfg:"pass_host_header"`
+	SkipProviderButton    bool          `flag:"skip-provider-button" cfg:"skip_provider_button"`
+	PassUserHeaders       bool          `flag:"pass-user-headers" cfg:"pass_user_headers"`
+	SSLInsecureSkipVerify bool          `flag:"ssl-insecure-skip-verify" cfg:"ssl_insecure_skip_verify"`
+	SetXAuthRequest       bool          `flag:"set-xauthrequest" cfg:"set_xauthrequest"`
+	SetAuthorization      bool          `flag:"set-authorization-header" cfg:"set_authorization_header"`
+	PassAuthorization     bool          `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
+	SkipAuthPreflight     bool          `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
 	FlushInterval         time.Duration `flag:"flush-interval" cfg:"flush_interval"`
 
 	// These options allow for other providers besides Google, with

--- a/options.go
+++ b/options.go
@@ -64,6 +64,7 @@ type Options struct {
 	SetAuthorization      bool     `flag:"set-authorization-header" cfg:"set_authorization_header"`
 	PassAuthorization     bool     `flag:"pass-authorization-header" cfg:"pass_authorization_header"`
 	SkipAuthPreflight     bool     `flag:"skip-auth-preflight" cfg:"skip_auth_preflight"`
+	FlushInterval         time.Duration `flag:"flush-interval" cfg:"flush_interval"`
 
 	// These options allow for other providers besides Google, with
 	// potential overrides.


### PR DESCRIPTION
Flush responses for streaming upstreams

## Description

When proxying streaming responses, it would not flush the response writer buffer until some seemingly random point (maybe the number of bytes?). This makes it flush every 1 second by default, but with a configurable interval.


## Motivation and Context

If you have an upstream that drip-feeds data (eg, a jenkins instance that streams its logs as they get generated), the proxy would lag behind, presumably until a buffer got filled enough for it to flush it.

## How Has This Been Tested?

Manually tested against an upstream that responded with streamed data over the course of many seconds.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
