### PR TITLE
redirect to original path after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - [#21](https://github.com/pusher/oauth2_proxy/pull/21) Docker Improvement (@yaegashi)
   - Move Docker base image from debian to alpine
   - Install ca-certificates in docker image
+- [#24](https://github.com/pusher/oauth2_proxy/pull/24) Redirect fix (@agentgonzo)
+  - After a successful login, you will be redirected to your original URL rather than /
 
 # v3.0.0
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -564,7 +564,10 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 
 	redirect = req.Form.Get("rd")
 	if redirect == "" || !strings.HasPrefix(redirect, "/") || strings.HasPrefix(redirect, "//") {
-		redirect = "/"
+		redirect = req.URL.Path
+		if strings.HasPrefix(redirect, p.ProxyPrefix) {
+			redirect = "/"
+		}
 	}
 
 	return

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mbland/hmacauth"
 	"github.com/pusher/oauth2_proxy/providers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -836,4 +837,37 @@ func TestRequestSignaturePostRequest(t *testing.T) {
 	st.MakeRequestWithExpectedKey("POST", payload, "foobar")
 	assert.Equal(t, 200, st.rw.Code)
 	assert.Equal(t, st.rw.Body.String(), "signatures match")
+}
+
+func TestGetRedirect(t *testing.T) {
+	options := NewOptions()
+	_ = options.Validate()
+	require.NotEmpty(t, options.ProxyPrefix)
+	proxy := NewOAuthProxy(options, func(s string) bool { return false })
+
+	tests := []struct {
+		name             string
+		url              string
+		expectedRedirect string
+	}{
+		{
+			name:             "request outside of ProxyPrefix redirects to original URL",
+			url:              "/foo/bar",
+			expectedRedirect: "/foo/bar",
+		},
+		{
+			name:             "request under of ProxyPrefix redirects to original URL",
+			url:              proxy.ProxyPrefix + "/foo/bar",
+			expectedRedirect: "/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", tt.url, nil)
+			redirect, err := proxy.GetRedirect(req)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedRedirect, redirect)
+		})
+	}
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -856,7 +856,7 @@ func TestGetRedirect(t *testing.T) {
 			expectedRedirect: "/foo/bar",
 		},
 		{
-			name:             "request under of ProxyPrefix redirects to original URL",
+			name:             "request under ProxyPrefix redirects to root",
 			url:              proxy.ProxyPrefix + "/foo/bar",
 			expectedRedirect: "/",
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After the user logs in, redirect them to their original URL rather than just /

## Motivation and Context

The user wants to go to their destination, no the root URL.

## How Has This Been Tested?

Run it against an upstream. Trash all cookies, then try to access it with a non-root URL

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
