### PR TITLE
Returns HTTP unauthorized for ajax requests instead of redirecting to the sign-in page

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -754,6 +754,8 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 		} else {
 			p.SignInPage(rw, req, http.StatusForbidden)
 		}
+	} else if status == http.StatusUnauthorized {
+		p.ErrorJSON(rw, status)
 	} else {
 		p.serveMux.ServeHTTP(rw, req)
 	}
@@ -826,6 +828,11 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	}
 
 	if session == nil {
+		// Check if is an ajax request and return unauthorized to avoid a redirect
+		// to the login page
+		if p.isAjax(req) {
+			return http.StatusUnauthorized
+		}
 		return http.StatusForbidden
 	}
 
@@ -893,4 +900,25 @@ func (p *OAuthProxy) CheckBasicAuth(req *http.Request) (*providers.SessionState,
 		return &providers.SessionState{User: pair[0]}, nil
 	}
 	return nil, fmt.Errorf("%s not in HtpasswdFile", pair[0])
+}
+
+// isAjax checks if a request is an ajax request
+func (p *OAuthProxy) isAjax(req *http.Request) bool {
+	acceptValues, ok := req.Header["accept"]
+	if !ok {
+		acceptValues = req.Header["Accept"]
+	}
+	const ajaxReq = "application/json"
+	for _, v := range acceptValues {
+		if v == ajaxReq {
+			return true
+		}
+	}
+	return false
+}
+
+// ErrorJSON returns the error code witht an application/json mime type
+func (p *OAuthProxy) ErrorJSON(rw http.ResponseWriter, code int) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(code)
 }

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -30,6 +30,8 @@ const (
 	// Cookies are limited to 4kb including the length of the cookie name,
 	// the cookie name can be up to 256 bytes
 	maxCookieLength = 3840
+
+	applicationJSON = "application/json"
 )
 
 // SignatureHeaders contains the headers to be signed by the hmac algorithm
@@ -908,7 +910,7 @@ func (p *OAuthProxy) isAjax(req *http.Request) bool {
 	if !ok {
 		acceptValues = req.Header["Accept"]
 	}
-	const ajaxReq = "application/json"
+	const ajaxReq = applicationJSON
 	for _, v := range acceptValues {
 		if v == ajaxReq {
 			return true
@@ -919,6 +921,6 @@ func (p *OAuthProxy) isAjax(req *http.Request) bool {
 
 // ErrorJSON returns the error code witht an application/json mime type
 func (p *OAuthProxy) ErrorJSON(rw http.ResponseWriter, code int) {
-	rw.Header().Set("Content-Type", "application/json")
+	rw.Header().Set("Content-Type", applicationJSON)
 	rw.WriteHeader(code)
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -903,35 +903,35 @@ func (test *ajaxRequestTest) getEndpoint(endpoint string, header http.Header) (i
 
 func testAjaxUnauthorizedRequest(t *testing.T, header http.Header) {
 	test := newAjaxRequestTest()
-	const endpoint = "/test"
+	endpoint := "/test"
 
 	code, rh, err := test.getEndpoint(endpoint, header)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusUnauthorized, code)
 	mime := rh.Get("Content-Type")
-	assert.Equal(t, "application/json", mime)
+	assert.Equal(t, applicationJSON, mime)
 }
 func TestAjaxUnauthorizedRequest1(t *testing.T) {
 	header := make(http.Header)
-	header.Add("accept", "application/json")
+	header.Add("accept", applicationJSON)
 
 	testAjaxUnauthorizedRequest(t, header)
 }
 
 func TestAjaxUnauthorizedRequest2(t *testing.T) {
 	header := make(http.Header)
-	header.Add("Accept", "application/json")
+	header.Add("Accept", applicationJSON)
 
 	testAjaxUnauthorizedRequest(t, header)
 }
 
 func TestAjaxForbiddendRequest(t *testing.T) {
 	test := newAjaxRequestTest()
-	const endpoint = "/test"
+	endpoint := "/test"
 	header := make(http.Header)
 	code, rh, err := test.getEndpoint(endpoint, header)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, code)
 	mime := rh.Get("Content-Type")
-	assert.NotEqual(t, "application/json", mime)
+	assert.NotEqual(t, applicationJSON, mime)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Returns HTTP unauthorized for ajax requests instead of redirecting to the sing-in page


<!--- Describe your changes in detail -->

## Motivation and Context

Normally, an ajax request expects an HTTP unauthorized back with a mime type application/json 
instead of an HTML page. 

The authentication logic is modified to return an HTTP unauthorized for ajax requests
instead of redirecting to the sign-in page with HTML content.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

The changed is covered with unit tests, and also we are using it since couple of months 
with an large RESTful application.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.