### PR TITLE
watcher: properly break out in nested blocks

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -45,7 +45,7 @@ func WatchForUpdates(filename string, done <-chan bool, action func()) {
 			select {
 			case _ = <-done:
 				log.Printf("Shutting down watcher for: %s", filename)
-				break
+				return
 			case event := <-watcher.Events:
 				// On Arch Linux, it appears Chmod events precede Remove events,
 				// which causes a race between action() and the coming Remove event.


### PR DESCRIPTION
## Description

Found via staticcheck:

```
watcher.go:48:5: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
```

## Motivation and Context

I wanted to fix any obviously wrong issues that `staticcheck` shows, if any. 


