### PR TITLE
WIP: Change cookie index separator to underscore

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -329,7 +329,7 @@ func splitCookie(c *http.Cookie) []*http.Cookie {
 	count := 0
 	for len(valueBytes) > 0 {
 		new := copyCookie(c)
-		new.Name = fmt.Sprintf("%s-%d", c.Name, count)
+		new.Name = fmt.Sprintf("%s_%d", c.Name, count)
 		count++
 		if len(valueBytes) < maxCookieLength {
 			new.Value = string(valueBytes)
@@ -357,7 +357,7 @@ func joinCookies(cookies []*http.Cookie) (*http.Cookie, error) {
 	for i := 1; i < len(cookies); i++ {
 		c.Value += cookies[i].Value
 	}
-	c.Name = strings.TrimRight(c.Name, "-0")
+	c.Name = strings.TrimRight(c.Name, "_0")
 	return c, nil
 }
 
@@ -374,7 +374,7 @@ func loadCookie(req *http.Request, cookieName string) (*http.Cookie, error) {
 	count := 0
 	for err == nil {
 		var c *http.Cookie
-		c, err = req.Cookie(fmt.Sprintf("%s-%d", cookieName, count))
+		c, err = req.Cookie(fmt.Sprintf("%s_%d", cookieName, count))
 		if err == nil {
 			cookies = append(cookies, c)
 			count++


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR changes the cookie separator charactor from a hyphen `-` to an underscore `_`.

<!--- Describe your changes in detail -->

## Motivation and Context
This is to achieve compatibility to nginx's auth_request directive. nginx doesn't support any other characters than alphanumerics and underscores when accessing cookie names via a variable.

So to build logic into nginx's config to deal with multiple `Set-Cookie:` headers, this is required. See also #29 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Simply looking at the `Set-Cookie:` response header and cookie names in the browser ;-)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.

I will add the corresponding config syntax to deal with multiple cookies in nginx to the README before we merge this PR.