### PR TITLE
Add Quay links to ARM repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,17 +47,31 @@ $(BINARY):
 
 .PHONY: docker
 docker:
-	docker build -f Dockerfile -t pusher/oauth2_proxy:latest .
+	docker build -f Dockerfile -t quay.io/pusher/oauth2_proxy:latest .
 
 .PHONY: docker-all
 docker-all: docker
-	docker build -f Dockerfile -t pusher/oauth2_proxy:latest-amd64 .
-	docker build -f Dockerfile -t pusher/oauth2_proxy:${VERSION} .
-	docker build -f Dockerfile -t pusher/oauth2_proxy:${VERSION}-amd64 .
-	docker build -f Dockerfile.arm64 -t pusher/oauth2_proxy:latest-arm64 .
-	docker build -f Dockerfile.arm64 -t pusher/oauth2_proxy:${VERSION}-arm64 .
-	docker build -f Dockerfile.armv6 -t pusher/oauth2_proxy:latest-armv6 .
-	docker build -f Dockerfile.armv6 -t pusher/oauth2_proxy:${VERSION}-armv6 .
+	docker build -f Dockerfile -t quay.io/pusher/oauth2_proxy:latest-amd64 .
+	docker build -f Dockerfile -t quay.io/pusher/oauth2_proxy:${VERSION} .
+	docker build -f Dockerfile -t quay.io/pusher/oauth2_proxy:${VERSION}-amd64 .
+	docker build -f Dockerfile.arm64 -t quay.io/pusher/oauth2_proxy:latest-arm64 .
+	docker build -f Dockerfile.arm64 -t quay.io/pusher/oauth2_proxy:${VERSION}-arm64 .
+	docker build -f Dockerfile.armv6 -t quay.io/pusher/oauth2_proxy:latest-armv6 .
+	docker build -f Dockerfile.armv6 -t quay.io/pusher/oauth2_proxy:${VERSION}-armv6 .
+
+.PHONY: docker-push
+docker-push:
+	docker push quay.io/pusher/oauth2_proxy:latest
+
+.PHONY: docker-push-all
+docker-push-all: docker-push
+	docker push quay.io/pusher/oauth2_proxy:latest-amd64
+	docker push quay.io/pusher/oauth2_proxy:${VERSION}
+	docker push quay.io/pusher/oauth2_proxy:${VERSION}-amd64
+	docker push quay.io/pusher/oauth2_proxy:latest-arm64
+	docker push quay.io/pusher/oauth2_proxy:${VERSION}-arm64
+	docker push quay.io/pusher/oauth2_proxy:latest-armv6
+	docker push quay.io/pusher/oauth2_proxy:${VERSION}-armv6
 
 .PHONY: test
 test: dep lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include .env
 BINARY := oauth2_proxy
-VERSION := $(shell git describe --always --long --dirty --tags 2>/dev/null || echo "undefined")
+VERSION := $(shell git describe --always --dirty --tags 2>/dev/null || echo "undefined")
 .NOTPARALLEL:
 
 .PHONY: all


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Now that we have ARM releases and ARM Dockerfiles, I have set up automated builds of `master` and tags on two Quay repos for ARM (`quay.io/pusher/oauth2_proxy-armv6`, `quay.io/pusher/oauth2_proxy-amd64`).

(Ignore the markdown linting that got mixed in with this)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #16 (@kskewes can you review this?)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually triggered builds of `master` which seem to have built from the Dockerfiles provided

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
