### PR TITLE
Add -skip-oidc-discovery option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changes since v3.1.0
 
 - [#68](https://github.com/pusher/oauth2_proxy/pull/68) forward X-Auth-Access-Token header (@davidholsgrove)
+- [#41](https://github.com/pusher/oauth2_proxy/pull/41) Added option to manually specify OIDC endpoints instead of relying on discovery
 
 # v3.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,6 @@ COPY . .
 # Fetch dependencies
 RUN dep ensure --vendor-only
 
-RUN rm -rvf vendor/github.com/coreos/go-oidc
-
-RUN git clone https://github.com/karrieretutor/go-oidc vendor/github.com/coreos/go-oidc
-
 # Build binary
 RUN ./configure && make build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ COPY . .
 # Fetch dependencies
 RUN dep ensure --vendor-only
 
+RUN rm -rvf vendor/github.com/coreos/go-oidc
+
+RUN git clone https://github.com/karrieretutor/go-oidc vendor/github.com/coreos/go-oidc
+
 # Build binary
 RUN ./configure && make build
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ Usage of oauth2_proxy:
   -login-url string: Authentication endpoint
   -oidc-issuer-url: the OpenID Connect issuer URL. ie: "https://accounts.google.com"
   -oidc-jwks-url string: OIDC JWKS URI for token verification; required if OIDC discovery is disabled
-  -oidc-userinfo-url string: OIDC Userinfo Endpoint; optional if OIDC discovery is disabled
   -pass-access-token: pass OAuth access_token to upstream via X-Forwarded-Access-Token header
   -pass-authorization-header: pass OIDC IDToken to upstream via Authorization Bearer header
   -pass-basic-auth: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream (default true)

--- a/README.md
+++ b/README.md
@@ -166,6 +166,26 @@ OpenID Connect is a spec for OAUTH 2.0 + identity that is implemented by many ma
     -cookie-secure=false
     -email-domain example.com
 
+#### Skip OIDC discovery
+
+Some providers do not support OIDC discovery via their issuer URL, so oauth2_proxy cannot simply grab the authorization, token and jwks URI endpoints from the provider's metadata.
+
+In this case, you can set the `-skip-oidc-discovery` option, and supply those required endpoints manually:
+
+```
+    -provider oidc
+    -client-id oauth2_proxy
+    -client-secret proxy
+    -redirect-url http://127.0.0.1:4180/oauth2/callback
+    -oidc-issuer-url http://127.0.0.1:5556
+    -skip-oidc-discovery
+    -login-url http://127.0.0.1:5556/authorize
+    -redeem-url http://127.0.0.1:5556/token
+    -oidc-jwks-url http://127.0.0.1:5556/keys
+    -cookie-secure=false
+    -email-domain example.com
+```
+
 ## Email Authentication
 
 To authorize by email domain use `--email-domain=yourcompany.com`. To authorize individual email addresses use `--authenticated-emails-file=/path/to/file` with one email per line. To authorize all email addresses use `--email-domain=*`.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ Usage of oauth2_proxy:
   -https-address string: <addr>:<port> to listen on for HTTPS clients (default ":443")
   -login-url string: Authentication endpoint
   -oidc-issuer-url: the OpenID Connect issuer URL. ie: "https://accounts.google.com"
+  -oidc-jwks-url string: OIDC JWKS URI for token verification; required if OIDC discovery is disabled
+  -oidc-userinfo-url string: OIDC Userinfo Endpoint; optional if OIDC discovery is disabled
   -pass-access-token: pass OAuth access_token to upstream via X-Forwarded-Access-Token header
   -pass-authorization-header: pass OIDC IDToken to upstream via Authorization Bearer header
   -pass-basic-auth: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream (default true)
@@ -232,6 +234,7 @@ Usage of oauth2_proxy:
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
   -skip-auth-preflight: will skip authentication for OPTIONS requests
   -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)
+  -skip-oidc-discovery: bypass OIDC endpoint discovery. login-url, redeem-url and oidc-jwks-url must be configured in this case
   -skip-provider-button: will skip sign-in-page to directly reach the next step: oauth/start
   -ssl-insecure-skip-verify: skip validation of certificates presented when using HTTPS
   -tls-cert string: path to certificate file

--- a/main.go
+++ b/main.go
@@ -77,7 +77,6 @@ func main() {
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
 	flagSet.Bool("skip-oidc-discovery", false, "Skip OIDC discovery and use manually supplied Endpoints")
-	flagSet.String("oidc-userinfo-url", "", "OpenID Connect user info URL (ie: https://graph.microsoft.com/oidc/userinfo)")
 	flagSet.String("oidc-jwks-url", "", "OpenID Connect JWKS URL (ie: https://www.googleapis.com/oauth2/v3/certs)")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")

--- a/main.go
+++ b/main.go
@@ -89,8 +89,6 @@ func main() {
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 
-	flagSet.String("b2c-policy", "", "Azure AD B2C Policy name")
-
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {

--- a/main.go
+++ b/main.go
@@ -89,6 +89,8 @@ func main() {
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 
+	flagSet.String("b2c-policy", "", "Azure AD B2C Policy name")
+
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {

--- a/main.go
+++ b/main.go
@@ -86,6 +86,8 @@ func main() {
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 
+	flagSet.String("b2c-policy", "", "Azure AD B2C Policy name")
+
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {

--- a/main.go
+++ b/main.go
@@ -76,6 +76,9 @@ func main() {
 
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
+	flagSet.Bool("skip-oidc-discovery", false, "Skip OIDC discovery and use manually supplied Endpoints")
+	flagSet.String("oidc-userinfo-url", "", "OpenID Connect user info URL (ie: https://graph.microsoft.com/oidc/userinfo)")
+	flagSet.String("oidc-jwks-url", "", "OpenID Connect JWKS URL (ie: https://www.googleapis.com/oauth2/v3/certs)")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")

--- a/options.go
+++ b/options.go
@@ -90,8 +90,6 @@ type Options struct {
 
 	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
-	B2CPolicy string `flag:"b2c-policy" cfg:"b2c_policy"`
-
 	// internal values that are set after config validation
 	redirectURL   *url.URL
 	proxyURLs     []*url.URL

--- a/options.go
+++ b/options.go
@@ -72,7 +72,6 @@ type Options struct {
 	Provider          string `flag:"provider" cfg:"provider"`
 	OIDCIssuerURL     string `flag:"oidc-issuer-url" cfg:"oidc_issuer_url"`
 	SkipOIDCDiscovery bool   `flag:"skip-oidc-discovery" cfg:"skip_oidc_discovery"`
-	OIDCUserInfoURL   string `flag:"oidc-userinfo-url" cfg:"oidc_userinfo_url"`
 	OIDCJwksURL       string `flag:"oidc-jwks-url" cfg:"oidc_jwks_url"`
 	LoginURL          string `flag:"login-url" cfg:"login_url"`
 	RedeemURL         string `flag:"redeem-url" cfg:"redeem_url"`

--- a/options.go
+++ b/options.go
@@ -141,7 +141,7 @@ func parseURL(toParse string, urltype string, msgs []string) (*url.URL, []string
 	return parsed, msgs
 }
 
-// OIDCManualTransport is a structu that is used for manual OIDC endpoints definition
+// OIDCManualTransport is a structure that is used for manual OIDC endpoints definition
 //
 type OIDCManualTransport struct {
 	Issuer                string `json:"issuer"`

--- a/options.go
+++ b/options.go
@@ -90,6 +90,8 @@ type Options struct {
 
 	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
+	B2CPolicy string `flag:"b2c-policy" cfg:"b2c_policy"`
+
 	// internal values that are set after config validation
 	redirectURL   *url.URL
 	proxyURLs     []*url.URL

--- a/options.go
+++ b/options.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -71,6 +74,9 @@ type Options struct {
 	// potential overrides.
 	Provider          string `flag:"provider" cfg:"provider"`
 	OIDCIssuerURL     string `flag:"oidc-issuer-url" cfg:"oidc_issuer_url"`
+	SkipOidcDiscovery bool   `flag:"skip-oidc-discovery" cfg:"skip_oidc_discovery"`
+	OIDCUserInfoURL   string `flag:"oidc-userinfo-url" cfg:"oidc_userinfo_url"`
+	OIDCJwksURL       string `flag:"oidc-jwks-url" cfg:"oidc_jwks_url"`
 	LoginURL          string `flag:"login-url" cfg:"login_url"`
 	RedeemURL         string `flag:"redeem-url" cfg:"redeem_url"`
 	ProfileURL        string `flag:"profile-url" cfg:"profile_url"`
@@ -123,6 +129,7 @@ func NewOptions() *Options {
 		PassAuthorization:    false,
 		ApprovalPrompt:       "force",
 		RequestLogging:       true,
+		SkipOidcDiscovery:    false,
 		RequestLoggingFormat: defaultRequestLoggingFormat,
 	}
 }
@@ -134,6 +141,32 @@ func parseURL(toParse string, urltype string, msgs []string) (*url.URL, []string
 			"error parsing %s-url=%q %s", urltype, toParse, err))
 	}
 	return parsed, msgs
+}
+
+// OIDCManualTransport is a structu that is used for manual OIDC endpoints definition
+//
+type OIDCManualTransport struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	JwksURI               string `json:"jwks_uri"`
+	UserInfoURL           string `json:"userinfo_endpoint"`
+}
+
+// RoundTrip fakes an HTTP request so that go-oidc receives a JSON response
+// from our custom definition instead of a response from the real discovery endpoint
+func (t *OIDCManualTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.HasSuffix(req.URL.Path, "/.well-known/openid-configuration") {
+		jsonResponse, err := json.Marshal(t)
+		manualBody := ioutil.NopCloser(bytes.NewReader(jsonResponse))
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       manualBody,
+		}, err
+	}
+
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 // Validate checks that required options are set and validates those that they
@@ -163,8 +196,35 @@ func (o *Options) Validate() error {
 	}
 
 	if o.OIDCIssuerURL != "" {
+
+		ctx := context.Background()
+
+		// Override discoverable provider data with a custom http.Client that fakes
+		// a discovery response with our manual setting on go-oidc side
+		// only if -skip-oidc-discovery is enabled
+		if o.SkipOidcDiscovery {
+			if o.LoginURL == "" {
+				msgs = append(msgs, "missing setting: login-url")
+			}
+			if o.RedeemURL == "" {
+				msgs = append(msgs, "missing setting: redeem-url")
+			}
+			if o.OIDCJwksURL == "" {
+				msgs = append(msgs, "missing setting: oidc-jwks-url")
+			}
+			ctx = oidc.ClientContext(ctx, &http.Client{
+				Transport: &OIDCManualTransport{
+					Issuer:                o.OIDCIssuerURL,
+					AuthorizationEndpoint: o.LoginURL,
+					TokenEndpoint:         o.RedeemURL,
+					JwksURI:               o.OIDCJwksURL,
+					UserInfoURL:           o.OIDCUserInfoURL,
+				},
+			})
+		}
+
 		// Configure discoverable provider data.
-		provider, err := oidc.NewProvider(context.Background(), o.OIDCIssuerURL, o.B2CPolicy)
+		provider, err := oidc.NewProvider(ctx, o.OIDCIssuerURL)
 		if err != nil {
 			return err
 		}

--- a/options.go
+++ b/options.go
@@ -84,6 +84,8 @@ type Options struct {
 
 	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 
+	B2CPolicy string `flag:"b2c-policy" cfg:"b2c_policy"`
+
 	// internal values that are set after config validation
 	redirectURL   *url.URL
 	proxyURLs     []*url.URL
@@ -162,7 +164,7 @@ func (o *Options) Validate() error {
 
 	if o.OIDCIssuerURL != "" {
 		// Configure discoverable provider data.
-		provider, err := oidc.NewProvider(context.Background(), o.OIDCIssuerURL)
+		provider, err := oidc.NewProvider(context.Background(), o.OIDCIssuerURL, o.B2CPolicy)
 		if err != nil {
 			return err
 		}

--- a/options.go
+++ b/options.go
@@ -167,9 +167,10 @@ func (o *Options) Validate() error {
 
 		ctx := context.Background()
 
-		// Override discoverable provider data with a custom http.Client that fakes
-		// a discovery response with our manual setting on go-oidc side
-		// only if -skip-oidc-discovery is enabled
+		// Construct a manual IDTokenVerifier from issuer URL & JWKS URI
+		// instead of metadata discovery if we enable -skip-oidc-discovery.
+		// In this case we need to make sure the required endpoints for
+		// the provider are configured.
 		if o.SkipOIDCDiscovery {
 			if o.LoginURL == "" {
 				msgs = append(msgs, "missing setting: login-url")

--- a/options.go
+++ b/options.go
@@ -142,7 +142,6 @@ func parseURL(toParse string, urltype string, msgs []string) (*url.URL, []string
 }
 
 // OIDCManualTransport is a structure that is used for manual OIDC endpoints definition
-
 //
 type OIDCManualTransport struct {
 	Issuer                string `json:"issuer"`

--- a/options.go
+++ b/options.go
@@ -144,6 +144,7 @@ func parseURL(toParse string, urltype string, msgs []string) (*url.URL, []string
 }
 
 // OIDCManualTransport is a structure that is used for manual OIDC endpoints definition
+
 //
 type OIDCManualTransport struct {
 	Issuer                string `json:"issuer"`

--- a/options_test.go
+++ b/options_test.go
@@ -256,7 +256,7 @@ func TestSkipOIDCDiscovery(t *testing.T) {
 	o := testOptions()
 	o.Provider = "oidc"
 	o.OIDCIssuerURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/v2.0/"
-	o.SkipOidcDiscovery = true
+	o.SkipOIDCDiscovery = true
 
 	err := o.Validate()
 	assert.Equal(t, "Invalid configuration:\n"+

--- a/options_test.go
+++ b/options_test.go
@@ -251,3 +251,20 @@ func TestValidateCookieBadName(t *testing.T) {
 	assert.Equal(t, err.Error(), "Invalid configuration:\n"+
 		fmt.Sprintf("  invalid cookie name: %q", o.CookieName))
 }
+
+func TestSkipOIDCDiscovery(t *testing.T) {
+	o := testOptions()
+	o.Provider = "oidc"
+	o.OIDCIssuerURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/v2.0/"
+	o.SkipOidcDiscovery = true
+
+	err := o.Validate()
+	assert.Equal(t, "Invalid configuration:\n"+
+		fmt.Sprintf("  missing setting: login-url\n  missing setting: redeem-url\n  missing setting: oidc-jwks-url"), err.Error())
+
+	o.LoginURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_sign_in"
+	o.RedeemURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/token?p=b2c_1_sign_in"
+	o.OIDCJwksURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/discovery/v2.0/keys"
+
+	assert.Equal(t, nil, o.Validate())
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the option to skip OIDC discovery by go-oidc and instead manually configure Authorization, Token and JWKS URI endpoints.

<!--- Describe your changes in detail -->

## Motivation and Context

Fixes #27 

Some OIDC providers either do not have a discovery endpoint (non-standard Enterprise solutions) or require additional URL parameters for specific user journey policies to be supplied (Microsoft Azure AD B2C). 

go-oidc calls the fixed `/.well-known/openid-configuration` endpoint of the configured OIDC issuer. When there is no issuer or when there are multiple policies defined via additional parameters, this method cannot be relied upon.

Fortunately, go-oidc provides the possibility to use a custom HTTP client via a client context. With this, we supply go-oidc with a "fake" HTTP client that always returns the manually configured Auth,Token and JWKS endpoints in a JSON response when it calls the discovery endpoint.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested this with Microsoft Azure AD B2C as OIDC Provider which uses an additional URL parameter for custom User Journeys. Manually setting the OIDC endpoints to a particular policy returns the proper user journey

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
