### PR TITLE
Fall back to using OIDC Subject instead of Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes since v3.1.0
 
+- [#57](https://github.com/pusher/oauth2_proxy/pull/57) Fall back to using OIDC Subject instead of Email (@aigarius)
 - [#85](https://github.com/pusher/oauth2_proxy/pull/85) Use non-root user in docker images (@kskewes)
 - [#68](https://github.com/pusher/oauth2_proxy/pull/68) forward X-Auth-Access-Token header (@davidholsgrove)
 - [#41](https://github.com/pusher/oauth2_proxy/pull/41) Added option to manually specify OIDC endpoints instead of relying on discovery

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -106,6 +106,7 @@ func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Tok
 
 	// Extract custom claims.
 	var claims struct {
+		Subject  string `json:"sub"`
 		Email    string `json:"email"`
 		Verified *bool  `json:"email_verified"`
 	}
@@ -114,7 +115,8 @@ func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Tok
 	}
 
 	if claims.Email == "" {
-		return nil, fmt.Errorf("id_token did not contain an email")
+		// TODO: Try getting email from /userinfo before falling back to Subject
+		claims.Email = claims.Subject
 	}
 	if claims.Verified != nil && !*claims.Verified {
 		return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)


### PR DESCRIPTION
Email is not mandatory field, Subject is mandatory and expected to be unique. Might want to take a look at UserInfo first, however.

Issue: #56