### PR TITLE
JWT bearer passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## Changes since v3.2.0
 
+- [#65](https://github.com/pusher/oauth2_proxy/pull/65) Improvements to authenticate requests with a JWT bearer token in the `Authorization` header via
+  the `-skip-jwt-bearer-token` options. 
+  - Additional verifiers can be configured via the `-extra-jwt-issuers` flag if the JWT issuers is either an OpenID provider or has a JWKS URL 
+  (e.g. `https://example.com/.well-known/jwks.json`).
 - [#180](https://github.com/pusher/outh2_proxy/pull/180) Minor refactor of core proxying path (@aeijdenberg).
 - [#175](https://github.com/pusher/outh2_proxy/pull/175) Bump go-oidc to v2.0.0 (@aeijdenberg).
   - Includes fix for potential signature checking issue when OIDC discovery is skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@
 - [#111](https://github.com/pusher/oauth2_proxy/pull/111) Add option for telling where to find a login.gov JWT key file (@timothy-spencer)
 - [#170](https://github.com/pusher/oauth2_proxy/pull/170) Restore binary tarball contents to be compatible with bitlys original tarballs (@zeha)
 - [#185](https://github.com/pusher/oauth2_proxy/pull/185) Fix an unsupported protocol scheme error during token validation when using the Azure provider (@jonas)
-
 - [#141](https://github.com/pusher/oauth2_proxy/pull/141) Check google group membership based on email address (@bchess)
   - Google Group membership is additionally checked via email address, allowing users outside a GSuite domain to be authorized.
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -41,6 +41,7 @@ Usage of oauth2_proxy:
   -custom-templates-dir string: path to custom html templates
   -display-htpasswd-form: display username / password login form if an htpasswd file is provided (default true)
   -email-domain value: authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
+  -extra-jwt-issuers: if -skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)
   -flush-interval: period between flushing response buffers when streaming responses (default "1s")
   -footer string: custom footer string. Use "-" to disable default footer.
   -gcp-healthchecks: will enable /liveness_check, /readiness_check, and / (with the proper user-agent) endpoints that will make it work well with GCP App Engine and GKE Ingresses (default false)
@@ -89,6 +90,7 @@ Usage of oauth2_proxy:
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
   -skip-auth-preflight: will skip authentication for OPTIONS requests
   -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)
+  -skip-jwt-bearer-tokens: will skip requests that have verified JWT bearer tokens
   -skip-oidc-discovery: bypass OIDC endpoint discovery. login-url, redeem-url and oidc-jwks-url must be configured in this case
   -skip-provider-button: will skip sign-in-page to directly reach the next step: oauth/start
   -ssl-insecure-skip-verify: skip validation of certificates presented when using HTTPS

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 	flagSet.Duration("flush-interval", time.Duration(1)*time.Second, "period between response flushing when streaming responses")
-	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens")
+	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens (default false)")
 	flagSet.Var(&jwtIssuers, "extra-jwt-issuers", "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	whitelistDomains := StringArray{}
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
+	jwtIssuers := StringArray{}
 	googleGroups := StringArray{}
 	redisSentinelConnectionURLs := StringArray{}
 
@@ -48,6 +49,8 @@ func main() {
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 	flagSet.Duration("flush-interval", time.Duration(1)*time.Second, "period between response flushing when streaming responses")
+	flagSet.Bool("skip-jwt-bearer-tokens", false, "will skip requests that have verified JWT bearer tokens")
+	flagSet.Var(&jwtIssuers, "extra-jwt-issuers", "if skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -917,7 +917,6 @@ func (p *OAuthProxy) GetJwtSession(req *http.Request) (*sessionsapi.SessionState
 		if claims.Verified != nil && !*claims.Verified {
 			return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
 		}
-		user := strings.Split(claims.Email, "@")[0]
 
 		session = &sessionsapi.SessionState{
 			AccessToken:  rawBearerToken,
@@ -925,7 +924,7 @@ func (p *OAuthProxy) GetJwtSession(req *http.Request) (*sessionsapi.SessionState
 			RefreshToken: "",
 			ExpiresOn:    bearerToken.Expiry,
 			Email:        claims.Email,
-			User:         user,
+			User:         claims.Email,
 		}
 		return session, nil
 	}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	b64 "encoding/base64"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-oidc"
 	"github.com/mbland/hmacauth"
 	"github.com/pusher/oauth2_proxy/cookie"
 	"github.com/pusher/oauth2_proxy/logger"
@@ -92,6 +94,8 @@ type OAuthProxy struct {
 	PassAuthorization   bool
 	skipAuthRegex       []string
 	skipAuthPreflight   bool
+	skipJwtBearerTokens bool
+	jwtBearerVerifiers  []*oidc.IDTokenVerifier
 	compiledRegex       []*regexp.Regexp
 	templates           *template.Template
 	Footer              string
@@ -206,6 +210,12 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		logger.Printf("compiled skip-auth-regex => %q", u)
 	}
 
+	if opts.SkipJwtBearerTokens {
+		logger.Printf("Skipping JWT tokens from configured OIDC issuer: %q", opts.OIDCIssuerURL)
+		for _, issuer := range opts.ExtraJwtIssuers {
+			logger.Printf("Skipping JWT tokens from extra JWT issuer: %q", issuer)
+		}
+	}
 	redirectURL := opts.redirectURL
 	if redirectURL.Path == "" {
 		redirectURL.Path = fmt.Sprintf("%s/callback", opts.ProxyPrefix)
@@ -239,25 +249,27 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		OAuthCallbackPath: fmt.Sprintf("%s/callback", opts.ProxyPrefix),
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 
-		ProxyPrefix:        opts.ProxyPrefix,
-		provider:           opts.provider,
-		sessionStore:       opts.sessionStore,
-		serveMux:           serveMux,
-		redirectURL:        redirectURL,
-		whitelistDomains:   opts.WhitelistDomains,
-		skipAuthRegex:      opts.SkipAuthRegex,
-		skipAuthPreflight:  opts.SkipAuthPreflight,
-		compiledRegex:      opts.CompiledRegex,
-		SetXAuthRequest:    opts.SetXAuthRequest,
-		PassBasicAuth:      opts.PassBasicAuth,
-		PassUserHeaders:    opts.PassUserHeaders,
-		BasicAuthPassword:  opts.BasicAuthPassword,
-		PassAccessToken:    opts.PassAccessToken,
-		SetAuthorization:   opts.SetAuthorization,
-		PassAuthorization:  opts.PassAuthorization,
-		SkipProviderButton: opts.SkipProviderButton,
-		templates:          loadTemplates(opts.CustomTemplatesDir),
-		Footer:             opts.Footer,
+		ProxyPrefix:         opts.ProxyPrefix,
+		provider:            opts.provider,
+		sessionStore:        opts.sessionStore,
+		serveMux:            serveMux,
+		redirectURL:         redirectURL,
+		whitelistDomains:    opts.WhitelistDomains,
+		skipAuthRegex:       opts.SkipAuthRegex,
+		skipAuthPreflight:   opts.SkipAuthPreflight,
+		skipJwtBearerTokens: opts.SkipJwtBearerTokens,
+		jwtBearerVerifiers:  opts.jwtBearerVerifiers,
+		compiledRegex:       opts.CompiledRegex,
+		SetXAuthRequest:     opts.SetXAuthRequest,
+		PassBasicAuth:       opts.PassBasicAuth,
+		PassUserHeaders:     opts.PassUserHeaders,
+		BasicAuthPassword:   opts.BasicAuthPassword,
+		PassAccessToken:     opts.PassAccessToken,
+		SetAuthorization:    opts.SetAuthorization,
+		PassAuthorization:   opts.PassAuthorization,
+		SkipProviderButton:  opts.SkipProviderButton,
+		templates:           loadTemplates(opts.CustomTemplatesDir),
+		Footer:              opts.Footer,
 	}
 }
 
@@ -693,26 +705,42 @@ func (p *OAuthProxy) Proxy(rw http.ResponseWriter, req *http.Request) {
 // Returns nil, ErrNeedsLogin if user needs to login.
 // Set-Cookie headers may be set on the response as a side-effect of calling this method.
 func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.Request) (*sessionsapi.SessionState, error) {
+	var session *sessionsapi.SessionState
+	var err error
 	var saveSession, clearSession, revalidated bool
+
+	if p.skipJwtBearerTokens && req.Header.Get("Authorization") != "" {
+		session, err = p.GetJwtSession(req)
+		if err != nil {
+			logger.Printf("Error validating JWT token from Authorization header: %s", err)
+		}
+		if session != nil {
+			saveSession = false
+		}
+	}
+
 	remoteAddr := getRemoteAddr(req)
-
-	session, err := p.LoadCookiedSession(req)
-	if err != nil {
-		logger.Printf("Error loading cookied session: %s", err)
+	if session == nil {
+		session, err = p.LoadCookiedSession(req)
+		if err != nil {
+			logger.Printf("Error loading cookied session: %s", err)
+		}
+		if session != nil && session.Age() > p.CookieRefresh && p.CookieRefresh != time.Duration(0) {
+			logger.Printf("Refreshing %s old session cookie for %s (refresh after %s)", session.Age(), session, p.CookieRefresh)
+			saveSession = true
+		}
 	}
-	if session != nil && session.Age() > p.CookieRefresh && p.CookieRefresh != time.Duration(0) {
-		logger.Printf("Refreshing %s old session cookie for %s (refresh after %s)", session.Age(), session, p.CookieRefresh)
-		saveSession = true
-	}
 
-	var ok bool
-	if ok, err = p.provider.RefreshSessionIfNeeded(session); err != nil {
-		logger.Printf("%s removing session. error refreshing access token %s %s", remoteAddr, err, session)
-		clearSession = true
-		session = nil
-	} else if ok {
-		saveSession = true
-		revalidated = true
+	if session != nil {
+		var ok bool
+		if ok, err = p.provider.RefreshSessionIfNeeded(session); err != nil {
+			logger.Printf("%s removing session. error refreshing access token %s %s", remoteAddr, err, session)
+			clearSession = true
+			session = nil
+		} else if ok {
+			saveSession = true
+			revalidated = true
+		}
 	}
 
 	if session != nil && session.IsExpired() {
@@ -853,4 +881,93 @@ func isAjax(req *http.Request) bool {
 func (p *OAuthProxy) ErrorJSON(rw http.ResponseWriter, code int) {
 	rw.Header().Set("Content-Type", applicationJSON)
 	rw.WriteHeader(code)
+}
+
+// GetJwtSession loads a session based on a JWT token in the authorization header.
+func (p *OAuthProxy) GetJwtSession(req *http.Request) (*sessionsapi.SessionState, error) {
+	rawBearerToken, err := p.findBearerToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	var session *sessionsapi.SessionState
+	for _, verifier := range p.jwtBearerVerifiers {
+		bearerToken, err := verifier.Verify(ctx, rawBearerToken)
+
+		if err != nil {
+			logger.Printf("failed to verify bearer token: %v", err)
+			continue
+		}
+
+		var claims struct {
+			Email    string `json:"email"`
+			Verified *bool  `json:"email_verified"`
+		}
+
+		if err := bearerToken.Claims(&claims); err != nil {
+			return nil, fmt.Errorf("failed to parse bearer token claims: %v", err)
+		}
+
+		if claims.Email == "" {
+			return nil, fmt.Errorf("id_token did not contain an email")
+		}
+
+		if claims.Verified != nil && !*claims.Verified {
+			return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
+		}
+		user := strings.Split(claims.Email, "@")[0]
+
+		session = &sessionsapi.SessionState{
+			AccessToken:  rawBearerToken,
+			IDToken:      rawBearerToken,
+			RefreshToken: "",
+			ExpiresOn:    bearerToken.Expiry,
+			Email:        claims.Email,
+			User:         user,
+		}
+		return session, nil
+	}
+	return nil, fmt.Errorf("unable to verify jwt token %s", req.Header.Get("Authorization"))
+}
+
+// findBearerToken finds a valid JWT token from the Authorization header of a given request.
+func (p *OAuthProxy) findBearerToken(req *http.Request) (string, error) {
+	auth := req.Header.Get("Authorization")
+	s := strings.SplitN(auth, " ", 2)
+	if len(s) != 2 {
+		return "", fmt.Errorf("invalid authorization header %s", auth)
+	}
+
+	var rawBearerToken string
+	if s[0] == "Bearer" {
+		rawBearerToken = s[1]
+	} else if s[0] == "Basic" {
+		// Check if we have a Bearer token masquerading in Basic
+		b, err := b64.StdEncoding.DecodeString(s[1])
+		if err != nil {
+			return "", err
+		}
+		pair := strings.SplitN(string(b), ":", 2)
+		if len(pair) != 2 {
+			return "", fmt.Errorf("invalid format %s", b)
+		}
+		user, password := pair[0], pair[1]
+
+		// check user, user+password, or just password for a token
+		jwtRegex := regexp.MustCompile(`^eyJ[a-zA-Z0-9_-]*\.eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+$`)
+		if jwtRegex.MatchString(user) {
+			// Support blank passwords or magic `x-oauth-basic` passwords - nothing else
+			if password == "" || password == "x-oauth-basic" {
+				rawBearerToken = user
+			}
+		} else if jwtRegex.MatchString(password) {
+			// support passwords and ignore user
+			rawBearerToken = password
+		}
+	} else {
+		return "", fmt.Errorf("invalid authorization header %s", auth)
+	}
+
+	return rawBearerToken, nil
 }

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -725,21 +725,21 @@ func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.R
 		if err != nil {
 			logger.Printf("Error loading cookied session: %s", err)
 		}
-		if session != nil && session.Age() > p.CookieRefresh && p.CookieRefresh != time.Duration(0) {
-			logger.Printf("Refreshing %s old session cookie for %s (refresh after %s)", session.Age(), session, p.CookieRefresh)
-			saveSession = true
-		}
-	}
 
-	if session != nil {
-		var ok bool
-		if ok, err = p.provider.RefreshSessionIfNeeded(session); err != nil {
-			logger.Printf("%s removing session. error refreshing access token %s %s", remoteAddr, err, session)
-			clearSession = true
-			session = nil
-		} else if ok {
-			saveSession = true
-			revalidated = true
+		if session != nil {
+			if session.Age() > p.CookieRefresh && p.CookieRefresh != time.Duration(0) {
+				logger.Printf("Refreshing %s old session cookie for %s (refresh after %s)", session.Age(), session, p.CookieRefresh)
+				saveSession = true
+			}
+
+			if ok, err := p.provider.RefreshSessionIfNeeded(session); err != nil {
+				logger.Printf("%s removing session. error refreshing access token %s %s", remoteAddr, err, session)
+				clearSession = true
+				session = nil
+			} else if ok {
+				saveSession = true
+				revalidated = true
+			}
 		}
 	}
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -901,6 +901,7 @@ func (p *OAuthProxy) GetJwtSession(req *http.Request) (*sessionsapi.SessionState
 		}
 
 		var claims struct {
+			Subject  string `json:"sub"`
 			Email    string `json:"email"`
 			Verified *bool  `json:"email_verified"`
 		}
@@ -910,7 +911,7 @@ func (p *OAuthProxy) GetJwtSession(req *http.Request) (*sessionsapi.SessionState
 		}
 
 		if claims.Email == "" {
-			return nil, fmt.Errorf("id_token did not contain an email")
+			claims.Email = claims.Subject
 		}
 
 		if claims.Verified != nil && !*claims.Verified {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -712,7 +712,7 @@ func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.R
 	if p.skipJwtBearerTokens && req.Header.Get("Authorization") != "" {
 		session, err = p.GetJwtSession(req)
 		if err != nil {
-			logger.Printf("Error validating JWT token from Authorization header: %s", err)
+			logger.Printf("Error retrieving session from token in Authorization header: %s", err)
 		}
 		if session != nil {
 			saveSession = false
@@ -938,9 +938,9 @@ func (p *OAuthProxy) findBearerToken(req *http.Request) (string, error) {
 	if len(s) != 2 {
 		return "", fmt.Errorf("invalid authorization header %s", auth)
 	}
-
+	jwtRegex := regexp.MustCompile(`^eyJ[a-zA-Z0-9_-]*\.eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+$`)
 	var rawBearerToken string
-	if s[0] == "Bearer" {
+	if s[0] == "Bearer" && jwtRegex.MatchString(s[1]) {
 		rawBearerToken = s[1]
 	} else if s[0] == "Basic" {
 		// Check if we have a Bearer token masquerading in Basic
@@ -955,7 +955,6 @@ func (p *OAuthProxy) findBearerToken(req *http.Request) (string, error) {
 		user, password := pair[0], pair[1]
 
 		// check user, user+password, or just password for a token
-		jwtRegex := regexp.MustCompile(`^eyJ[a-zA-Z0-9_-]*\.eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+$`)
 		if jwtRegex.MatchString(user) {
 			// Support blank passwords or magic `x-oauth-basic` passwords - nothing else
 			if password == "" || password == "x-oauth-basic" {
@@ -965,8 +964,9 @@ func (p *OAuthProxy) findBearerToken(req *http.Request) (string, error) {
 			// support passwords and ignore user
 			rawBearerToken = password
 		}
-	} else {
-		return "", fmt.Errorf("invalid authorization header %s", auth)
+	}
+	if rawBearerToken == "" {
+		return "", fmt.Errorf("no valid bearer token found in authorization header")
 	}
 
 	return rawBearerToken, nil

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto"
 	"encoding/base64"
 	"fmt"
-	"github.com/coreos/go-oidc"
 	"io"
 	"io/ioutil"
 	"net"
@@ -17,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-oidc"
 	"github.com/mbland/hmacauth"
 	"github.com/pusher/oauth2_proxy/logger"
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1179,7 +1179,7 @@ func TestGetJwtSession(t *testing.T) {
 
 	// Bearer
 	session, _ := p.GetJwtSession(req)
-	assert.Equal(t, session.User, "john")
+	assert.Equal(t, session.User, "john@example.com")
 	assert.Equal(t, session.Email, "john@example.com")
 	assert.Equal(t, session.ExpiresOn, time.Unix(1912151821, 0))
 	assert.Equal(t, session.IDToken, goodJwt)
@@ -1223,12 +1223,12 @@ func TestGetJwtSession(t *testing.T) {
 
 	// Check PassAuthorization, should overwrite Basic header
 	assert.Equal(t, req.Header.Get("Authorization"), authHeader)
-	assert.Equal(t, req.Header.Get("X-Forwarded-User"), "john")
+	assert.Equal(t, req.Header.Get("X-Forwarded-User"), "john@example.com")
 	assert.Equal(t, req.Header.Get("X-Forwarded-Email"), "john@example.com")
 
 	// SetAuthorization and SetXAuthRequest
 	assert.Equal(t, rw.Header().Get("Authorization"), authHeader)
-	assert.Equal(t, rw.Header().Get("X-Auth-Request-User"), "john")
+	assert.Equal(t, rw.Header().Get("X-Auth-Request-User"), "john@example.com")
 	assert.Equal(t, rw.Header().Get("X-Auth-Request-Email"), "john@example.com")
 
 }

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1185,7 +1185,7 @@ func TestGetJwtSession(t *testing.T) {
 	assert.Equal(t, session.IDToken, goodJwt)
 
 	jwtProviderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("%#v", r)
+		logger.Printf("%#v", r)
 		var payload string
 		payload = r.Header.Get("Authorization")
 		if payload == "" {

--- a/options.go
+++ b/options.go
@@ -61,8 +61,8 @@ type Options struct {
 
 	Upstreams             []string      `flag:"upstream" cfg:"upstreams" env:"OAUTH2_PROXY_UPSTREAMS"`
 	SkipAuthRegex         []string      `flag:"skip-auth-regex" cfg:"skip_auth_regex" env:"OAUTH2_PROXY_SKIP_AUTH_REGEX"`
-	SkipJwtBearerTokens   bool          `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens"`
-	ExtraJwtIssuers       []string      `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers"`
+	SkipJwtBearerTokens   bool          `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens" env:"OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS"`
+	ExtraJwtIssuers       []string      `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers" env:"OAUTH2_PROXY_EXTRA_JWT_ISSUERS"`
 	PassBasicAuth         bool          `flag:"pass-basic-auth" cfg:"pass_basic_auth" env:"OAUTH2_PROXY_PASS_BASIC_AUTH"`
 	BasicAuthPassword     string        `flag:"basic-auth-password" cfg:"basic_auth_password" env:"OAUTH2_PROXY_BASIC_AUTH_PASSWORD"`
 	PassAccessToken       bool          `flag:"pass-access-token" cfg:"pass_access_token" env:"OAUTH2_PROXY_PASS_ACCESS_TOKEN"`

--- a/options.go
+++ b/options.go
@@ -171,8 +171,8 @@ func NewOptions() *Options {
 	}
 }
 
-// JwtIssuer hold parsed JWT issuer info that's used to construct a verifier.
-type JwtIssuer struct {
+// jwtIssuer hold parsed JWT issuer info that's used to construct a verifier.
+type jwtIssuer struct {
 	issuerURI string
 	audience  string
 }
@@ -260,7 +260,7 @@ func (o *Options) Validate() error {
 		}
 		// Configure extra issuers
 		if len(o.ExtraJwtIssuers) > 0 {
-			var jwtIssuers []JwtIssuer
+			var jwtIssuers []jwtIssuer
 			jwtIssuers, msgs = parseJwtIssuers(o.ExtraJwtIssuers, msgs)
 			for _, jwtIssuer := range jwtIssuers {
 				verifier, err := newVerifierFromJwtIssuer(jwtIssuer)
@@ -459,9 +459,9 @@ func parseSignatureKey(o *Options, msgs []string) []string {
 }
 
 // parseJwtIssuers takes in an array of strings in the form of issuer=audience
-// and parses to an array of JwtIssuer structs.
-func parseJwtIssuers(issuers []string, msgs []string) ([]JwtIssuer, []string) {
-	var parsedIssuers []JwtIssuer
+// and parses to an array of jwtIssuer structs.
+func parseJwtIssuers(issuers []string, msgs []string) ([]jwtIssuer, []string) {
+	var parsedIssuers []jwtIssuer
 	for _, jwtVerifier := range issuers {
 		components := strings.Split(jwtVerifier, "=")
 		if len(components) < 2 {
@@ -469,14 +469,14 @@ func parseJwtIssuers(issuers []string, msgs []string) ([]JwtIssuer, []string) {
 			continue
 		}
 		uri, audience := components[0], strings.Join(components[1:], "=")
-		parsedIssuers = append(parsedIssuers, JwtIssuer{issuerURI: uri, audience: audience})
+		parsedIssuers = append(parsedIssuers, jwtIssuer{issuerURI: uri, audience: audience})
 	}
 	return parsedIssuers, msgs
 }
 
-// newVerifierFromJwtIssuer takes in issuer information in JwtIssuer info and returns
+// newVerifierFromJwtIssuer takes in issuer information in jwtIssuer info and returns
 // a verifier for that issuer.
-func newVerifierFromJwtIssuer(jwtIssuer JwtIssuer) (*oidc.IDTokenVerifier, error) {
+func newVerifierFromJwtIssuer(jwtIssuer jwtIssuer) (*oidc.IDTokenVerifier, error) {
 	config := &oidc.Config{
 		ClientID: jwtIssuer.audience,
 	}

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -128,7 +128,7 @@ func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Tok
 		IDToken:      rawIDToken,
 		RefreshToken: token.RefreshToken,
 		CreatedAt:    time.Now(),
-		ExpiresOn:    token.Expiry,
+		ExpiresOn:    idToken.Expiry,
 		Email:        claims.Email,
 		User:         claims.Subject,
 	}, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds support to skip JWT bearer tokens, when the issuer is either the configured issuer (if using an OIDC issuer) or a set of additional JWT issuers.

## Motivation and Context

This is an implementation for #18.

## How Has This Been Tested?

Tested in a kubernetes environment.

You need to get your token. An easy thing to do is to deploy an application behind oauth2_proxy that just prints it, then you can grab that token and re-request the same URL. Other than that, you can get it from the oauth2_proxy container, if it's running. For example, in kubernetes:

```bash
kubectl exec -it oauth2-proxy-4444444444-qrstu /bin/sh
apk add --update tcpdump
tcpdump -A -s 0 'tcp and (((ip[2:2] - ((ip[0]&0xf)<<2)) - ((tcp[12]&0xf0)>>2)) != 0)' -i eth0
```

...then look for X-Auth-Request-Token, assuming you configured oauth2_proxy with `-pass-authorization-header`.

From there, you can just do something like the following:

```bash
curl --header "Authorization: Bearer $TOKEN" https://example.com/my-protected-page
```

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
