### PR TITLE
Encrypt and decrypt the email and user in the cookie

### DIFF
--- a/providers/session_state_test.go
+++ b/providers/session_state_test.go
@@ -27,7 +27,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	}
 	encoded, err := s.EncodeSessionState(c)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, 4, strings.Count(encoded, "|"))
+	assert.Equal(t, 5, strings.Count(encoded, "|"))
 
 	ss, err := DecodeSessionState(encoded, c)
 	t.Logf("%#v", ss)
@@ -43,8 +43,8 @@ func TestSessionStateSerialization(t *testing.T) {
 	ss, err = DecodeSessionState(encoded, c2)
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "user", ss.User)
-	assert.Equal(t, s.Email, ss.Email)
+	assert.NotEqual(t, "user", ss.User)
+	assert.NotEqual(t, s.Email, ss.Email)
 	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
 	assert.NotEqual(t, s.AccessToken, ss.AccessToken)
 	assert.NotEqual(t, s.IDToken, ss.IDToken)
@@ -65,7 +65,7 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	}
 	encoded, err := s.EncodeSessionState(c)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, 4, strings.Count(encoded, "|"))
+	assert.Equal(t, 5, strings.Count(encoded, "|"))
 
 	ss, err := DecodeSessionState(encoded, c)
 	t.Logf("%#v", ss)
@@ -80,8 +80,8 @@ func TestSessionStateSerializationWithUser(t *testing.T) {
 	ss, err = DecodeSessionState(encoded, c2)
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, s.User, ss.User)
-	assert.Equal(t, s.Email, ss.Email)
+	assert.NotEqual(t, s.User, ss.User)
+	assert.NotEqual(t, s.Email, ss.Email)
 	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
 	assert.NotEqual(t, s.AccessToken, ss.AccessToken)
 	assert.NotEqual(t, s.RefreshToken, ss.RefreshToken)


### PR DESCRIPTION
… provided

<!--- Provide a general summary of your changes in the Title above -->

## Description

This change does one thing:
- if a cypher is provided, it encrypts also the email and user with the same logic and algorithm as the rest of the fields from the session state.

<!--- Describe your changes in detail -->

## Motivation and Context

This is the PR for the issue #60 .
Don't expose any information part of the cookie, information that can be easily retrieved if not encrypted.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All the test from session_state_test are passing.
Testing in our environments.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
