### PR TITLE
Access token forwarding through nginx auth request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [#35](https://github.com/pusher/oauth2_proxy/pull/35) arm and arm64 binary releases (@kskewes)
   - Add armv6 and arm64 to Makefile `release` target
 - [#37](https://github.com/pusher/oauth2_proxy/pull/37) cross build arm and arm64 docker images (@kskewes)
+- [#68](https://github.com/pusher/oauth2_proxy/pull/68) forward X-Auth-Access-Token header (@davidholsgrove)
 
 # v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Changes since v3.1.0
 
+- [#68](https://github.com/pusher/oauth2_proxy/pull/68) forward X-Auth-Access-Token header (@davidholsgrove)
+
 # v3.1.0
 
 ## Release highlights
@@ -42,7 +44,6 @@
 - [#35](https://github.com/pusher/oauth2_proxy/pull/35) arm and arm64 binary releases (@kskewes)
   - Add armv6 and arm64 to Makefile `release` target
 - [#37](https://github.com/pusher/oauth2_proxy/pull/37) cross build arm and arm64 docker images (@kskewes)
-- [#68](https://github.com/pusher/oauth2_proxy/pull/68) forward X-Auth-Access-Token header (@davidholsgrove)
 
 # v3.0.0
 

--- a/README.md
+++ b/README.md
@@ -422,8 +422,10 @@ server {
     # requires running with --set-xauthrequest flag
     auth_request_set $user   $upstream_http_x_auth_request_user;
     auth_request_set $email  $upstream_http_x_auth_request_email;
+    auth_request_set $token  $upstream_http_x_auth_request_access_token;  # Available with --pass-access-token flag
     proxy_set_header X-User  $user;
     proxy_set_header X-Email $email;
+    proxy_set_header X-Token $token;
 
     # if you enabled --cookie-refresh, this is needed for it to work with auth_request
     auth_request_set $auth_cookie $upstream_http_set_cookie;

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ server {
 
     # if you enabled --pass-access-token, this will pass the token to the backend
     auth_request_set $token  $upstream_http_x_auth_request_access_token;
-    proxy_set_header X-Token $token;
+    proxy_set_header X-Access-Token $token;
 
     # if you enabled --cookie-refresh, this is needed for it to work with auth_request
     auth_request_set $auth_cookie $upstream_http_set_cookie;

--- a/README.md
+++ b/README.md
@@ -422,9 +422,11 @@ server {
     # requires running with --set-xauthrequest flag
     auth_request_set $user   $upstream_http_x_auth_request_user;
     auth_request_set $email  $upstream_http_x_auth_request_email;
-    auth_request_set $token  $upstream_http_x_auth_request_access_token;  # Available with --pass-access-token flag
     proxy_set_header X-User  $user;
     proxy_set_header X-Email $email;
+
+    # if you enabled --pass-access-token, this will pass the token to the backend
+    auth_request_set $token  $upstream_http_x_auth_request_access_token;
     proxy_set_header X-Token $token;
 
     # if you enabled --cookie-refresh, this is needed for it to work with auth_request

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -880,6 +880,9 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		if session.Email != "" {
 			rw.Header().Set("X-Auth-Request-Email", session.Email)
 		}
+		if p.PassAccessToken && session.AccessToken != "" {
+			rw.Header().Set("X-Auth-Request-Access-Token", session.AccessToken)
+		}
 	}
 	if p.PassAccessToken && session.AccessToken != "" {
 		req.Header["X-Forwarded-Access-Token"] = []string{session.AccessToken}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This enables expected behavior when using:
```
set_xauthrequest = true
pass_access_token = true
```
If both of these are set, the access token will be included in an `X-Auth-Request-Access-Token` header, following the `X-Auth-Request-*` pattern used for `User` and `Email`.

The access token allows for further validation by upstream services.

## Motivation and Context

Re-targeting of @patrickfuller's PR from original bitly/oauth2_proxy which wasn't merged before fork to pusher/oauth2_proxy.
Original review and discussion available on the PR and issue:
https://github.com/bitly/oauth2_proxy/pull/424
https://github.com/bitly/oauth2_proxy/issues/420

## How Has This Been Tested?
Kubernetes helm charts for oauth2_proxy and keycloak

nginx-ingress annotations;
```
annotations:
            kubernetes.io/ingress.class: nginx
            nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Access-Token, Authorization
            nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
            nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$request_uri"
            nginx.ingress.kubernetes.io/configuration-snippet: |
                auth_request_set $name_upstream_1 $upstream_cookie_name_1;
                access_by_lua_block {
                    if ngx.var.name_upstream_1 ~= "" then
                    ngx.header["Set-Cookie"] = "name_1=" .. ngx.var.name_upstream_1 .. ngx.var.auth_cookie:match("(; .*)")
                    end
                }
```

Confirmed X-Auth-Request-Access-Token received by backend, and successfully decoded the JWT access token.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
