### PR TITLE
Fixes deletion of splitted cookies - Issue #69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes since v3.1.0
 
+- [#70](https://github.com/pusher/oauth2_proxy/pull/70) Fix handling of splitted cookies (@einfachchr)
 - [#92](https://github.com/pusher/oauth2_proxy/pull/92) Merge websocket proxy feature from openshift/oauth-proxy (@butzist)
 - [#57](https://github.com/pusher/oauth2_proxy/pull/57) Fall back to using OIDC Subject instead of Email (@aigarius)
 - [#85](https://github.com/pusher/oauth2_proxy/pull/85) Use non-root user in docker images (@kskewes)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -452,9 +452,16 @@ func (p *OAuthProxy) SetCSRFCookie(rw http.ResponseWriter, req *http.Request, va
 // ClearSessionCookie creates a cookie to unset the user's authentication cookie
 // stored in the user's session
 func (p *OAuthProxy) ClearSessionCookie(rw http.ResponseWriter, req *http.Request) {
-	cookies := p.MakeSessionCookie(req, "", time.Hour*-1, time.Now())
-	for _, clr := range cookies {
-		http.SetCookie(rw, clr)
+	reqCookies := req.Cookies()
+	var cookies []*http.Cookie
+
+	for _, c := range reqCookies {
+		if strings.HasPrefix(c.Name, p.CookieName) {
+			clearCookie := p.makeCookie(req, c.Name, "", time.Hour*-1, time.Now())
+
+			http.SetCookie(rw, clearCookie)
+			cookies = append(cookies, clearCookie)
+		}
 	}
 
 	// ugly hack because default domain changed

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -458,7 +458,7 @@ func (p *OAuthProxy) ClearSessionCookie(rw http.ResponseWriter, req *http.Reques
 	// matches CookieName, CookieName_<number>
 	var cookieNameRegex = regexp.MustCompile(fmt.Sprintf("^%s(_\\d+)?$", p.CookieName))
 
-	for _, c := range reqCookies {
+	for _, c := range req.Cookies() {
 		if cookieNameRegex.MatchString(c.Name) {
 			clearCookie := p.makeCookie(req, c.Name, "", time.Hour*-1, time.Now())
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -452,7 +452,6 @@ func (p *OAuthProxy) SetCSRFCookie(rw http.ResponseWriter, req *http.Request, va
 // ClearSessionCookie creates a cookie to unset the user's authentication cookie
 // stored in the user's session
 func (p *OAuthProxy) ClearSessionCookie(rw http.ResponseWriter, req *http.Request) {
-	reqCookies := req.Cookies()
 	var cookies []*http.Cookie
 
 	// matches CookieName, CookieName_<number>

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -455,8 +455,11 @@ func (p *OAuthProxy) ClearSessionCookie(rw http.ResponseWriter, req *http.Reques
 	reqCookies := req.Cookies()
 	var cookies []*http.Cookie
 
+	// matches CookieName, CookieName_<number>
+	var cookieNameRegex = regexp.MustCompile(fmt.Sprintf("^%s(_\\d+)?$", p.CookieName))
+
 	for _, c := range reqCookies {
-		if strings.HasPrefix(c.Name, p.CookieName) {
+		if cookieNameRegex.MatchString(c.Name) {
 			clearCookie := p.makeCookie(req, c.Name, "", time.Hour*-1, time.Now())
 
 			http.SetCookie(rw, clearCookie)

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1075,12 +1075,12 @@ func TestClearSplitCookie(t *testing.T) {
 		Value: "test1",
 	})
 	req.AddCookie(&http.Cookie{
-		Name:  "oauth2-0",
-		Value: "oauth2-0",
+		Name:  "oauth2_0",
+		Value: "oauth2_0",
 	})
 	req.AddCookie(&http.Cookie{
-		Name:  "oauth2-1",
-		Value: "oauth2-1",
+		Name:  "oauth2_1",
+		Value: "oauth2_1",
 	})
 
 	p.ClearSessionCookie(rw, req)

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1064,3 +1064,47 @@ func TestAjaxForbiddendRequest(t *testing.T) {
 	mime := rh.Get("Content-Type")
 	assert.NotEqual(t, applicationJSON, mime)
 }
+
+func TestClearSplittedCookie(t *testing.T) {
+	p := OAuthProxy{CookieName: "oauth2"}
+	var rw = httptest.NewRecorder()
+	req := httptest.NewRequest("get", "/", nil)
+
+	req.AddCookie(&http.Cookie{
+		Name:  "test1",
+		Value: "test1",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  "oauth2-0",
+		Value: "oauth2-0",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  "oauth2-1",
+		Value: "oauth2-1",
+	})
+
+	p.ClearSessionCookie(rw, req)
+	header := rw.Header()
+
+	assert.Equal(t, 3, len(header["Set-Cookie"]), "should have 3 set-cookie header entries")
+}
+
+func TestClearNotSplittedCookie(t *testing.T) {
+	p := OAuthProxy{CookieName: "oauth2", CookieDomain: "abc"}
+	var rw = httptest.NewRecorder()
+	req := httptest.NewRequest("get", "/", nil)
+
+	req.AddCookie(&http.Cookie{
+		Name:  "test1",
+		Value: "test1",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  "oauth2",
+		Value: "oauth2",
+	})
+
+	p.ClearSessionCookie(rw, req)
+	header := rw.Header()
+
+	assert.Equal(t, 1, len(header["Set-Cookie"]), "should have 1 set-cookie header entries")
+}

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1065,8 +1065,8 @@ func TestAjaxForbiddendRequest(t *testing.T) {
 	assert.NotEqual(t, applicationJSON, mime)
 }
 
-func TestClearSplittedCookie(t *testing.T) {
-	p := OAuthProxy{CookieName: "oauth2"}
+func TestClearSplitCookie(t *testing.T) {
+	p := OAuthProxy{CookieName: "oauth2", CookieDomain: "abc"}
 	var rw = httptest.NewRecorder()
 	req := httptest.NewRequest("get", "/", nil)
 
@@ -1086,10 +1086,10 @@ func TestClearSplittedCookie(t *testing.T) {
 	p.ClearSessionCookie(rw, req)
 	header := rw.Header()
 
-	assert.Equal(t, 3, len(header["Set-Cookie"]), "should have 3 set-cookie header entries")
+	assert.Equal(t, 2, len(header["Set-Cookie"]), "should have 3 set-cookie header entries")
 }
 
-func TestClearNotSplittedCookie(t *testing.T) {
+func TestClearSingleCookie(t *testing.T) {
 	p := OAuthProxy{CookieName: "oauth2", CookieDomain: "abc"}
 	var rw = httptest.NewRecorder()
 	req := httptest.NewRequest("get", "/", nil)


### PR DESCRIPTION
This pull requests changes how the cookies are deleted on logout. It changes how the cookie names are
determined.

If you have any questions / suggestions, I'd be glad to add these.

## Description

For problem description see Issue #69. 

ClearSessionCookie() is changed to search the request cookies for cookies set by this proxy (identified by 
name prefix). For each of these a "reset cookie" is generated and set into the response header.

The change only affects the way the cookie names are determined.

## Motivation and Context

Fixes Issue #69. A user cannot be logged out in case of splitted cookies.

## How Has This Been Tested?

This is tested by unit tests (oauthproxy_test.go - TestClearSplittedCookie, TestClearNotSplittedCookie)
and this is running in our production environment.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
