### PR TITLE
build: fix: configure fails if GOPATH environment variable not set

### DIFF
--- a/configure
+++ b/configure
@@ -106,6 +106,7 @@ check_docker_version() {
 
 check_go_env() {
   echo -n "Checking \$GOPATH... "
+  GOPATH="$(go env GOPATH)"
   if [ -z "$GOPATH" ]; then
     printf "${RED}invalid${NC} - GOPATH not set\n"
     exit 1


### PR DESCRIPTION
Fix that `configure` fails if the default `GOPATH` (`~/go`) is used and the`GOPATH` environment variable is not set.

## Description

    build: fix: configure fails if GOPATH environment variable not set
    
    If the GOPATH enviroment variable was not set, go uses the default
    GOPATH (~/go/).
    
    The configure script was only checking if the GOPATH environment
    is set. If it wasn't the script was failing.
    
    Instead of checking if the GOPATH environment variable is set, check if
    "go env GOPATH" returns a non-emtpy string.


## Motivation and Context

Allows to run `configure` with the default `GOPATH` and an unset `GOPATH` environment variable.

## How Has This Been Tested?

Running `./configure` and `make`

## Checklist:
- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
