### PR TITLE
fix(dockerfile): Run as non-root user and group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes since v3.1.0
 
+- [#82](https://github.com/pusher/oauth2_proxy/pull/82) Docker run as non-root user and group (@kskewes)
 - [#68](https://github.com/pusher/oauth2_proxy/pull/68) forward X-Auth-Access-Token header (@davidholsgrove)
 
 # v3.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,8 @@ FROM alpine:3.8
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 
+RUN addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy
+RUN chown oauth2proxy:oauth2proxy /bin/oauth2_proxy
+USER oauth2proxy
+
 ENTRYPOINT ["/bin/oauth2_proxy"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -19,4 +19,8 @@ FROM arm64v8/alpine:3.8
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 
+RUN addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy
+RUN chown oauth2proxy:oauth2proxy /bin/oauth2_proxy
+USER oauth2proxy
+
 ENTRYPOINT ["/bin/oauth2_proxy"]

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -19,4 +19,8 @@ FROM arm32v6/alpine:3.8
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 
+RUN addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy
+RUN chown oauth2proxy:oauth2proxy /bin/oauth2_proxy
+USER oauth2proxy
+
 ENTRYPOINT ["/bin/oauth2_proxy"]


### PR DESCRIPTION
## Description

Run as non-root system user and group `oauth2proxy` with UID/GID `2000` to avoid clashing with typical local users.
An alternative to creating a separate user is to chown binary and run as `USER nobody`, which also works, can amend this PR if required.

## Motivation and Context

Least access privileges.
Close: https://github.com/pusher/oauth2_proxy/issues/78

## How Has This Been Tested?

Locally with Docker (`-version`):
```
$ ps aux | grep oauth2
2000     25192  6.0  0.0      0     0 ?        Ds   15:53   0:00 [oauth2_proxy]
```

Running in Kubernetes 1.13 with the following also specified:
```
        securityContext:
          readOnlyRootFilesystem: true
          runAsNonRoot: true
          runAsUser: 10001
```
```
$ kubectl exec -it -n oauth2-proxy oauth2-proxy-85c9f58ffc-dz9lr sh
/opt $ whoami
whoami: unknown uid 10001
/opt $ ps aux
PID   USER     TIME  COMMAND
    1 10001     0:00 /opt/oauth2_proxy --whitelist-domain=.faceme.com --cookie-domain=faceme.com --email-domain=faceme.com --upstream=file:///dev/null --http-address=0.0.0.0:4180
   11 10001     0:00 sh
   17 10001     0:00 ps aux
```


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
