### PR TITLE
Add id_token refresh to Google provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#68](https://github.com/pusher/oauth2_proxy/pull/68) forward X-Auth-Access-Token header (@davidholsgrove)
 - [#41](https://github.com/pusher/oauth2_proxy/pull/41) Added option to manually specify OIDC endpoints instead of relying on discovery
+- [#83](https://github.com/pusher/oauth2_proxy/pull/83) Add `id_token` refresh to Google provider (@leki75)
 
 # v3.1.0
 


### PR DESCRIPTION
Token refresh does not update id_token in session when using Google provider.

## Description
Token refresh does not update id_token in session, so JWT token passed to the backend application is expired while the access_token is updated. 

## Motivation and Context
Add id_token refresh to Google provider because the JWT token provided by set-authorization-header is outdated after a token refresh.

## How Has This Been Tested?
It is tested manually requesting the bearer token from the backend application.
