### PR TITLE
 Rename github API parameter: limit -> per_page

### DIFF
--- a/providers/github.go
+++ b/providers/github.go
@@ -73,7 +73,7 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 	pn := 1
 	for {
 		params := url.Values{
-			"per_page": {"200"},
+			"per_page": {"100"},
 			"page":  {strconv.Itoa(pn)},
 		}
 
@@ -138,7 +138,7 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 	}
 
 	params := url.Values{
-		"per_page": {"200"},
+		"per_page": {"100"},
 	}
 
 	endpoint := &url.URL{

--- a/providers/github.go
+++ b/providers/github.go
@@ -73,7 +73,7 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 	pn := 1
 	for {
 		params := url.Values{
-			"limit": {"200"},
+			"per_page": {"200"},
 			"page":  {strconv.Itoa(pn)},
 		}
 
@@ -138,7 +138,7 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 	}
 
 	params := url.Values{
-		"limit": {"200"},
+		"per_page": {"200"},
 	}
 
 	endpoint := &url.URL{

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -31,7 +31,7 @@ func testGitHubBackend(payload []string) *httptest.Server {
 	pathToQueryMap := map[string][]string{
 		"/user":        {""},
 		"/user/emails": {""},
-		"/user/orgs":   {"per_page=200&page=1", "per_page=200&page=2", "per_page=200&page=3"},
+		"/user/orgs":   {"per_page=100&page=1", "per_page=100&page=2", "per_page=100&page=3"},
 	}
 
 	return httptest.NewServer(http.HandlerFunc(

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -31,7 +31,7 @@ func testGitHubBackend(payload []string) *httptest.Server {
 	pathToQueryMap := map[string][]string{
 		"/user":        {""},
 		"/user/emails": {""},
-		"/user/orgs":   {"per_page=100&page=1", "per_page=100&page=2", "per_page=100&page=3"},
+		"/user/orgs":   {"page=1&per_page=100", "page=2&per_page=100", "page=3&per_page=100"},
 	}
 
 	return httptest.NewServer(http.HandlerFunc(
@@ -123,7 +123,7 @@ func TestGitHubProviderGetEmailAddressWithOrg(t *testing.T) {
 
 	session := &SessionState{AccessToken: "imaginary_access_token"}
 	email, err := p.GetEmailAddress(session)
-	assert.Equal(t, nil, err)
+	assert.Nil(t, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
 }
 

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -31,7 +31,7 @@ func testGitHubBackend(payload []string) *httptest.Server {
 	pathToQueryMap := map[string][]string{
 		"/user":        {""},
 		"/user/emails": {""},
-		"/user/orgs":   {"limit=200&page=1", "limit=200&page=2", "limit=200&page=3"},
+		"/user/orgs":   {"per_page=200&page=1", "per_page=200&page=2", "per_page=200&page=3"},
 	}
 
 	return httptest.NewServer(http.HandlerFunc(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously the github api uses the 'limit' parameter to set the maximum number
of entries returned in a response. The name was changed to 'per_page'. I changed
all occurances of the limit paramter with the new name.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By default the github API returns a limited number of results for the "/user/teams" endppint. AFAIR its something in the range of 20. If a user is member of >20 teams, the oauth2_proxy will only get the first 20 and does not know about the remaining teams. This leads to an "Invalid Account" response, even if the user is a member of the required team.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built a new docker image with my modifications and deployed it into my setup. With these changes I am able to authenticate with an affected user account.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
