### PR TITLE
Support OAUTH2_PROXY_REDIRECT_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The following environment variables can be used in place of the corresponding co
 - `OAUTH2_PROXY_COOKIE_DOMAIN`
 - `OAUTH2_PROXY_COOKIE_EXPIRE`
 - `OAUTH2_PROXY_COOKIE_REFRESH`
+- `OAUTH2_PROXY_REDIRECT_URL`
 - `OAUTH2_PROXY_SIGNATURE_KEY`
 
 ## SSL Configuration

--- a/options.go
+++ b/options.go
@@ -24,7 +24,7 @@ type Options struct {
 	ProxyPrefix  string `flag:"proxy-prefix" cfg:"proxy-prefix"`
 	HTTPAddress  string `flag:"http-address" cfg:"http_address"`
 	HTTPSAddress string `flag:"https-address" cfg:"https_address"`
-	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url"`
+	RedirectURL  string `flag:"redirect-url" cfg:"redirect_url" env:"OAUTH2_PROXY_REDIRECT_URL"`
 	ClientID     string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
 	ClientSecret string `flag:"client-secret" cfg:"client_secret" env:"OAUTH2_PROXY_CLIENT_SECRET"`
 	TLSCertFile  string `flag:"tls-cert" cfg:"tls_cert_file"`


### PR DESCRIPTION
In addition to the `-redirect-url` CLI arg, support the corresponding
`OAUTH2_PROXY_REDIRECT_URL` environment variable.

We have `staging` and `production` instances, and want to configure each through environment variables as the URLs differ.