### PR TITLE
Structured logging support using zap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-stretch AS builder
+FROM golang:1.12.0-stretch AS builder
 
 # Download tools
 RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
@@ -6,16 +6,18 @@ RUN chmod +x $GOPATH/bin/dep
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
-COPY . .
+COPY ./Gopkg.* ./
 
 # Fetch dependencies
 RUN dep ensure --vendor-only
 
+COPY . .
 # Build binary
 RUN ./configure && make build
 
 # Copy binary to alpine
-FROM alpine:3.8
+# FROM alpine:3.8
+FROM gcr.io/distroless/static:latest
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,9 @@ COPY . .
 # Build binary
 RUN ./configure && make build
 
-# Copy binary to alpine
-# FROM alpine:3.8
 FROM gcr.io/distroless/static:latest
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 
-RUN addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy
-USER oauth2proxy
-
+USER 2000:2000
 ENTRYPOINT ["/bin/oauth2_proxy"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,20 +2,20 @@
 
 
 [[projects]]
-  digest = "1:b24249f5a5e6fbe1eddc94b25973172339ccabeadef4779274f3ed0167c18812"
+  digest = "1:25e90949d88e66bcbb646626a293c77a97237b37a8f854c1e8ae817b74b5c2cf"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = ""
-  revision = "2d3a6656c17a60b0815b7e06ab0be04eacb6e613"
-  version = "v0.16.0"
+  revision = "c9474f2f8deb81759839474b6bd1726bbfe1c1c4"
+  version = "v0.36.0"
 
 [[projects]]
-  digest = "1:289dd4d7abfb3ad2b5f728fbe9b1d5c1bf7d265a3eb9ef92869af1f7baba4c7a"
+  digest = "1:e4b30804a381d7603b8a344009987c1ba351c26043501b23b8c7ce21f0b67474"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
   pruneopts = ""
-  revision = "b26d9c308763d68093482582cea63d69be07a0f0"
-  version = "v0.3.0"
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
 
 [[projects]]
   digest = "1:512883404c2a99156e410e9880e3bb35ecccc0c07c1159eb204b5f3ef3c431b3"
@@ -27,27 +27,35 @@
 
 [[projects]]
   branch = "v2"
-  digest = "1:e5a238f8fa890e529d7e493849bbae8988c9e70344e4630cc4f9a11b00516afb"
+  digest = "1:b309e289595a48e42a31c5ef538060817e9e6941065a5e9e841b0e813b51d445"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
   pruneopts = ""
-  revision = "77e7f2010a464ade7338597afe650dfcffbe2ca8"
+  revision = "66476e0267012774b2f9767d2d37a317d1f1aac3"
 
 [[projects]]
-  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = ""
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
-  version = "v1.1.0"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
+  digest = "1:d3d38150b6d77b2aad42a9e105170538b6563518993d43df78a1add6e31cce62"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   pruneopts = ""
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "c823c79ea1570fb5ff454033735a8e68575d1d0f"
+  version = "v1.3.0"
+
+[[projects]]
+  digest = "1:0f51cee70b0d254dbc93c22666ea2abf211af81c1701a96d04e2284b408621db"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
 
 [[projects]]
   digest = "1:af67386ca553c04c6222f7b5b2f17bc97a5dfb3b81b706882c7fd8c72c30cf8f"
@@ -59,11 +67,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9408fb9c637c103010e5147469c232ce6b68edc840879cc730a2a15918e6cae8"
+  digest = "1:15c0562bca5d78ac087fb39c211071dc124e79fb18f8b7c3f8a0bc7ffcb2a38e"
   name = "github.com/mreiferson/go-options"
   packages = ["."]
   pruneopts = ""
-  revision = "77551d20752b54535462404ad9d877ebdb26e53d"
+  revision = "20ba7d382d05facb01e02eb777af0c5f229c5c95"
 
 [[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
@@ -75,50 +83,94 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:386e12afcfd8964907c92dffd106860c0dedd71dbefae14397b77b724a13343b"
+  digest = "1:de5481dda0c081b66450e391bbb1a5c4435b13e3c0bbf0133ba1a5baeda7b7af"
   name = "github.com/pquerna/cachecontrol"
   packages = [
     ".",
     "cacheobject",
   ]
   pruneopts = ""
-  revision = "0dec1b30a0215bb68605dfc568e8855066c9202d"
+  revision = "1555304b9b35fdd2b425bccf1a5613677705e7d0"
+
+[[projects]]
+  digest = "1:9a3c631555e0351fdc4e696577bb63afd90c399d782a8462dba9d100d7021db3"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:3926a4ec9a4ff1a072458451aa2d9b98acd059a45b38f7335d31e06c3d6a0159"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
   pruneopts = ""
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
+  digest = "1:74f86c458e82e1c4efbab95233e0cf51b7cc02dc03193be9f62cd81224e10401"
+  name = "go.uber.org/atomic"
+  packages = ["."]
+  pruneopts = ""
+  revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
+  version = "v1.3.2"
+
+[[projects]]
+  digest = "1:22c7effcb4da0eacb2bb1940ee173fac010e9ef3c691f5de4b524d538bd980f5"
+  name = "go.uber.org/multierr"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:246f378f80fba6fcf0f191c486b6613265abd2bc0f2fa55a36b928c67352021e"
+  name = "go.uber.org/zap"
+  packages = [
+    ".",
+    "buffer",
+    "internal/bufferpool",
+    "internal/color",
+    "internal/exit",
+    "zapcore",
+  ]
+  pruneopts = ""
+  revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
+  version = "v1.9.1"
+
+[[projects]]
   branch = "master"
-  digest = "1:f6a006d27619a4d93bf9b66fe1999b8c8d1fa62bdc63af14f10fbe6fcaa2aa1a"
+  digest = "1:7a77b79efe106f3304dcf50dc86836151758f246169b527722552a5eb2ae14fc"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
     "blowfish",
     "ed25519",
     "ed25519/internal/edwards25519",
+    "pbkdf2",
+    "ssh/terminal",
   ]
   pruneopts = ""
-  revision = "9f005a07e0d31d45e6656d241bb5c0f2efd4bc94"
+  revision = "8dd112bcdc25174059e45e07517d9fc663123347"
 
 [[projects]]
   branch = "master"
-  digest = "1:130b1bec86c62e121967ee0c69d9c263dc2d3ffe6c7c9a82aca4071c4d068861"
+  digest = "1:7489cf41e267d966cbc16d9b98622e7124818af9339d5466aaec4fc736c404c0"
   name = "golang.org/x/net"
   packages = [
     "context",
     "context/ctxhttp",
   ]
   pruneopts = ""
-  revision = "9dfe39835686865bff950a07b394c12a98ddc811"
+  revision = "16b79f2e4e95ea23b2bf9903c9809ff7b013ce85"
 
 [[projects]]
   branch = "master"
-  digest = "1:4a61176e8386727e4847b21a5a2625ce56b9c518bc543a28226503e701265db0"
+  digest = "1:ffae4a89b63a2c845533a393b3340f8696898b11b71da1b187f82f08135c23a0"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -128,11 +180,22 @@
     "jwt",
   ]
   pruneopts = ""
-  revision = "9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402"
+  revision = "e64efc72b421e893cbf63f17ba2221e7d6d0b0f3"
 
 [[projects]]
   branch = "master"
-  digest = "1:dc1fb726dbbe79c86369941eae1e3b431b8fc6f11dbd37f7899dc758a43cc3ed"
+  digest = "1:e9f4395061c4001e3a32b7ab02cb4fa62b50bafaa3245e3f84cc80f637df61a6"
+  name = "golang.org/x/sys"
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
+  revision = "b6889370fb1098ed892bd3400d189bb6a3355813"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ed83b2bca87381d4f8c1245b25765d1f09142d882dec454e66e42210b6f246a9"
   name = "google.golang.org/api"
   packages = [
     "admin/directory/v1",
@@ -141,10 +204,10 @@
     "googleapi/internal/uritemplates",
   ]
   pruneopts = ""
-  revision = "8791354e7ab150705ede13637a18c1fcc16b62e8"
+  revision = "3127cb28a723bbc4166c461077c944c405ac4bf8"
 
 [[projects]]
-  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
+  digest = "1:bc09e719c4e2a15d17163f5272d9a3131c45d77542b7fdc53ff518815bc19ab3"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -159,8 +222,8 @@
     "urlfetch",
   ]
   pruneopts = ""
-  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
-  version = "v1.0.0"
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:cb5b2a45a3dd41c01ff779c54ae4c8aab0271d6d3b3f734c8a8bd2c890299ef2"
@@ -171,7 +234,7 @@
   version = "v1.2.11"
 
 [[projects]]
-  digest = "1:be4ed0a2b15944dd777a663681a39260ed05f9c4e213017ed2e2255622c8820c"
+  digest = "1:17a5466442de01b86c8d5a4aa6d93311f6907a5d7e6a18b306be7e0d9a240647"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
@@ -179,8 +242,8 @@
     "json",
   ]
   pruneopts = ""
-  revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
-  version = "v2.1.3"
+  revision = "628223f44a71f715d2881ea69afc795a1e9c01be"
+  version = "v2.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -191,7 +254,11 @@
     "github.com/coreos/go-oidc",
     "github.com/mbland/hmacauth",
     "github.com/mreiferson/go-options",
+    "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "go.uber.org/zap",
+    "go.uber.org/zap/zapcore",
     "golang.org/x/crypto/bcrypt",
     "golang.org/x/oauth2",
     "golang.org/x/oauth2/google",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,3 +38,4 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/crypto"
+

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ Usage of oauth2_proxy:
   -htpasswd-file string: additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption
   -http-address string: [http://]<addr>:<port> or unix://<path> to listen on for HTTP clients (default "127.0.0.1:4180")
   -https-address string: <addr>:<port> to listen on for HTTPS clients (default ":443")
+  -http-log-path string: **bLog** file path for http request logs. Defaults to stdout. (default "/dev/stdout")
+  -log-level value: Log level to use for logging oauth2_proxy messages. (default debug)
+  -log-path string: Log file path for oauth2_proxy logs. (default "/dev/stdout")
   -login-url string: Authentication endpoint
   -oidc-issuer-url: the OpenID Connect issuer URL. ie: "https://accounts.google.com"
   -oidc-jwks-url string: OIDC JWKS URI for token verification; required if OIDC discovery is disabled
@@ -245,7 +248,6 @@ Usage of oauth2_proxy:
   -redeem-url string: Token redemption endpoint
   -redirect-url string: the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
   -request-logging: Log requests to stdout (default true)
-  -request-logging-format: Template for request log lines (see "Logging Format" paragraph below)
   -resource string: The resource that is protected (Azure AD only)
   -scope string: OAuth scope specification
   -set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
@@ -385,22 +387,26 @@ following:
 - [rc3.org: Using HMAC to authenticate Web service
   requests](http://rc3.org/2011/12/02/using-hmac-to-authenticate-web-service-requests/)
 
-## Logging Format
+## Logging
 
-By default, OAuth2 Proxy logs requests to stdout in a format similar to Apache Combined Log.
+There are two logging sources: OAuth2_Proxy logs and HTTP request logs. 
 
-```
-<REMOTE_ADDRESS> - <user@domain.com> [19/Mar/2015:17:20:19 -0400] <HOST_HEADER> GET <UPSTREAM_HOST> "/path/" HTTP/1.1 "<USER_AGENT>" <RESPONSE_CODE> <RESPONSE_BYTES> <REQUEST_DURATION>
-```
+### OAuth2_Proxy Logs
 
-If you require a different format than that, you can configure it with the `-request-logging-format` flag.
-The default format is configured as follows:
+By default, OAuth2_Proxy logs are written as `json` to `stdout`. This can be configured by the option `log-path` to log to a differnt file. Typical log levels are also supported and configurable, via `log-level` option. Log levels must be provided in lower case in command line. They are documented [here](https://github.com/uber-go/zap/blob/master/level.go).
 
-```
-{{.Client}} - {{.Username}} [{{.Timestamp}}] {{.Host}} {{.RequestMethod}} {{.Upstream}} {{.RequestURI}} {{.Protocol}} {{.UserAgent}} {{.StatusCode}} {{.ResponseSize}} {{.RequestDuration}}
+```json
+{"level":"info","ts":"2019-03-06T14:49:54.162-0800","caller":"oauth2_proxy/logging_handler.go:147","msg":"HTTP Request","Client":"::1","Host":"localhost:4180","Protocol":"HTTP/1.1","RequestDuration":0.000163047,"RequestMethod":"GET","RequestURI":"/favicon.ico","ResponseSize":2493,"StatusCode":403,"Timestamp":"2019-03-06T14:49:54.162-0800","Upstream":"-","UserAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36","Username":"-"}
 ```
 
-[See `logMessageData` in `logging_handler.go`](./logging_handler.go) for all available variables.
+### Request Logs
+
+By default, requests are logged to `stdout` in `json` format. This can be configured by the option `http-log-path` to log to a different file. 
+
+```json
+{"level":"info","ts":"2019-03-06T14:49:53.841-0800","caller":"oauth2_proxy/logging_handler.go:147","msg":"HTTP Request","Client":"::1","Host":"localhost:4180","Protocol":"HTTP/1.1","RequestDuration":0.000620123,"RequestMethod":"GET","RequestURI":"/","ResponseSize":2482,"StatusCode":403,"Timestamp":"2019-03-06T14:49:53.841-0800","Upstream":"-","UserAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36","Username":"-"}
+```
+
 
 ## Adding a new Provider
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Usage of oauth2_proxy:
   -http-address string: [http://]<addr>:<port> or unix://<path> to listen on for HTTP clients (default "127.0.0.1:4180")
   -https-address string: <addr>:<port> to listen on for HTTPS clients (default ":443")
   -http-log-path string: **bLog** file path for http request logs. Defaults to stdout. (default "/dev/stdout")
+  -json-logging: Log OAuth2_Proxy in json format. Default is human-friendly partial json format. (default false)
   -log-level value: Log level to use for logging oauth2_proxy messages. (default debug)
   -log-path string: Log file path for oauth2_proxy logs. (default "/dev/stdout")
   -login-url string: Authentication endpoint
@@ -393,8 +394,20 @@ There are two logging sources: OAuth2_Proxy logs and HTTP request logs.
 
 ### OAuth2_Proxy Logs
 
-By default, OAuth2_Proxy logs are written as `json` to `stdout`. This can be configured by the option `log-path` to log to a differnt file. Typical log levels are also supported and configurable, via `log-level` option. Log levels must be provided in lower case in command line. They are documented [here](https://github.com/uber-go/zap/blob/master/level.go).
+By default, OAuth2_Proxy logs are written to `stdout`. This can be configured by the option `log-path` to log to a differnt file. Typical log levels are also supported and configurable, via `log-level` option. Log levels must be provided in lower case in command line. They are documented [here](https://github.com/uber-go/zap/blob/master/level.go).
 
+Two modes of logging are supported: `console` and `json`. `json` logs are enabled by setting `-json-logging` flag to `true`.
+
+_`console` logs_
+```2019-03-07T23:02:51.056-0800    INFO    oauth2_proxy/options.go:173     Validing OIDC Issuer URL        {"oidc_issuer_url": "https://company.oktapreview.com"}
+2019-03-07T23:02:52.193-0800    DEBUG   oauth2_proxy/options.go:213     Discovered OIDC configuration   {"oidc_issuer_url": "https://company.oktapreview.com", "AuthURL": "https://company.oktapreview.com/oauth2/v1/authorize", "TokenURL": "https://company.oktapreview.com/oauth2/v1/token"}
+2019-03-07T23:02:52.193-0800    INFO    oauth2_proxy/options.go:222     Configured OIDC scopes  {"scopes": "openid email profile"}
+2019-03-07T23:02:52.193-0800    INFO    oauth2_proxy/oauthproxy.go:162  Mapping path to upstream        {"path": "/", "upstream": "https://localhost:10443"}
+2019-03-07T23:02:52.193-0800    INFO    oauth2_proxy/oauthproxy.go:196  OAuthProxy configured   {"provider": "OpenID Connect", "clientid": "somesecretclientid"}
+2019-03-07T23:02:52.193-0800    INFO    oauth2_proxy/oauthproxy.go:204  Cookie Settings {"name": "_oauth2_proxy", "secure": false, "httponly": true, "expiry": 36000, "domain": "localhost", "refresh": "disabled"}
+{"level":"info","ts":"2019-03-07T23:02:52.194-0800","caller":"oauth2_proxy/http.go:64","msg":"HTTP Listening","listenAddress":":4180"}
+```
+_`json` logs_
 ```json
 {"level":"info","ts":"2019-03-06T14:49:54.162-0800","caller":"oauth2_proxy/logging_handler.go:147","msg":"HTTP Request","Client":"::1","Host":"localhost:4180","Protocol":"HTTP/1.1","RequestDuration":0.000163047,"RequestMethod":"GET","RequestURI":"/favicon.ico","ResponseSize":2493,"StatusCode":403,"Timestamp":"2019-03-06T14:49:54.162-0800","Upstream":"-","UserAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36","Username":"-"}
 ```

--- a/http.go
+++ b/http.go
@@ -2,21 +2,28 @@ package main
 
 import (
 	"crypto/tls"
-	"log"
 	"net"
 	"net/http"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // Server represents an HTTP server
 type Server struct {
 	Handler http.Handler
 	Opts    *Options
+
+	logger *zap.Logger
 }
 
 // ListenAndServe will serve traffic on HTTP or HTTPS depending on TLS options
 func (s *Server) ListenAndServe() {
+	config := zap.NewProductionConfig()
+	config.OutputPaths = []string{s.Opts.HTTPLogPath}
+	s.logger, _ = config.Build()
+	defer s.logger.Sync()
 	if s.Opts.TLSKeyFile != "" || s.Opts.TLSCertFile != "" {
 		s.ServeHTTPS()
 	} else {
@@ -47,17 +54,23 @@ func (s *Server) ServeHTTP() {
 
 	listener, err := net.Listen(networkType, listenAddr)
 	if err != nil {
-		log.Fatalf("FATAL: listen (%s, %s) failed - %s", networkType, listenAddr, err)
+		s.logger.Fatal("Failed to listen",
+			zap.String("networkType", networkType),
+			zap.String("listenAddress", listenAddr),
+			zap.String("error", err.Error()))
 	}
-	log.Printf("HTTP: listening on %s", listenAddr)
+	s.logger.Info("HTTP Listening",
+		zap.String("listenAddress", listenAddr))
 
 	server := &http.Server{Handler: s.Handler}
 	err = server.Serve(listener)
 	if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-		log.Printf("ERROR: http.Serve() - %s", err)
+		s.logger.Error("Error while serving with http.Serve()",
+			zap.String("error", err.Error()))
 	}
 
-	log.Printf("HTTP: closing %s", listener.Addr())
+	s.logger.Info("Closing HTTP Server",
+		zap.String("listeningAddress", listener.Addr().String()))
 }
 
 // ServeHTTPS constructs a net.Listener and starts handling HTTPS requests
@@ -75,24 +88,31 @@ func (s *Server) ServeHTTPS() {
 	config.Certificates = make([]tls.Certificate, 1)
 	config.Certificates[0], err = tls.LoadX509KeyPair(s.Opts.TLSCertFile, s.Opts.TLSKeyFile)
 	if err != nil {
-		log.Fatalf("FATAL: loading tls config (%s, %s) failed - %s", s.Opts.TLSCertFile, s.Opts.TLSKeyFile, err)
+		s.logger.Fatal("Error loading TLS configuration",
+			zap.String("tlsCertFile", s.Opts.TLSCertFile),
+			zap.String("tlsKeyFile", s.Opts.TLSKeyFile),
+			zap.String("error", err.Error()))
 	}
 
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		log.Fatalf("FATAL: listen (%s) failed - %s", addr, err)
+		s.logger.Fatal("Error listening",
+			zap.String("listenAddress", addr),
+			zap.String("error", err.Error()))
 	}
-	log.Printf("HTTPS: listening on %s", ln.Addr())
+	s.logger.Info("Listening HTTPS",
+		zap.String("listeningAddress", ln.Addr().String()))
 
 	tlsListener := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, config)
 	srv := &http.Server{Handler: s.Handler}
 	err = srv.Serve(tlsListener)
 
 	if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-		log.Printf("ERROR: https.Serve() - %s", err)
+		s.logger.Error("Error while serving https.Serve()",
+			zap.String("error", err.Error()))
 	}
-
-	log.Printf("HTTPS: closing %s", tlsListener.Addr())
+	s.logger.Info("Closing HTTPS servrer",
+		zap.String("listeningAddress", tlsListener.Addr().String()))
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted

--- a/http.go
+++ b/http.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // Server represents an HTTP server
@@ -21,6 +22,7 @@ type Server struct {
 // ListenAndServe will serve traffic on HTTP or HTTPS depending on TLS options
 func (s *Server) ListenAndServe() {
 	config := zap.NewProductionConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	config.OutputPaths = []string{s.Opts.HTTPLogPath}
 	s.logger, _ = config.Build()
 	defer s.logger.Sync()

--- a/level_flag.go
+++ b/level_flag.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"go.uber.org/zap/zapcore"
+)
+
+// LevelFlag is a Zap log level
+type LevelFlag zapcore.Level
+
+// NewLevelFlagAt creates a LevelFlag at the given level
+func NewLevelFlagAt(l zapcore.Level) LevelFlag {
+	return LevelFlag(l)
+}
+
+// Set sets a new value to LevelFlag
+func (lf *LevelFlag) Set(s string) error {
+	buf := []byte(s)
+	var lvl zapcore.Level
+	err := lvl.UnmarshalText(buf)
+	*lf = LevelFlag(lvl)
+	return err
+}
+
+// Level returns the level as AtomicLevel
+func (lf *LevelFlag) Level() zapcore.Level {
+	return zapcore.Level(*lf)
+}
+
+// Get returns the LevelFlag value
+func (lf *LevelFlag) Get() interface{} {
+	return LevelFlag(*lf)
+}
+
+// String() returns the string representation
+func (lf *LevelFlag) String() string {
+	lvl := zapcore.Level(*lf)
+	return lvl.String()
+}

--- a/level_flag_test.go
+++ b/level_flag_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestLevelFlagSetLevel(t *testing.T) {
+	lf := NewLevelFlagAt(zap.InfoLevel)
+	t.Logf("Initial lf = %d", lf)
+	expected := zap.WarnLevel
+	t.Logf("Setting level : %d", expected)
+	lf.Set("warn")
+
+	t.Logf("After Set() : lf = %d, Get() = %d", lf, lf.Get())
+	if zapcore.Level(lf.Get().(LevelFlag)) != expected {
+		t.Error("SetLevel failed")
+	}
+}
+
+var leveltests = []struct {
+	in  zapcore.Level
+	out string
+}{
+	{zap.DebugLevel, "debug"},
+	{zap.InfoLevel, "info"},
+	{zap.WarnLevel, "warn"},
+	{zap.ErrorLevel, "error"},
+	{zap.FatalLevel, "fatal"},
+	{zap.PanicLevel, "panic"},
+}
+
+func TestLevelFlagString(t *testing.T) {
+	for _, tt := range leveltests {
+		t.Run(tt.in.String(), func(t *testing.T) {
+			lf := NewLevelFlagAt(tt.in)
+			if lf.String() != tt.out {
+				t.Errorf("got %q, want %q:", lf.String(), tt.out)
+			}
+		})
+	}
+}
+
+func TestLevelFlagSet(t *testing.T) {
+	for _, tt := range leveltests {
+		t.Run(tt.in.String(), func(t *testing.T) {
+			lf := NewLevelFlagAt(zap.InfoLevel)
+			lf.Set(tt.out)
+			val := lf.Get().(LevelFlag)
+			if zapcore.Level(val) != tt.in {
+				t.Errorf("got %q, want %q:", val, tt.in)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -11,10 +11,26 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/mreiferson/go-options"
+	"go.uber.org/zap"
 )
 
+var (
+	logger    *zap.Logger
+	logConfig *zap.Config
+)
+
+func initializeZapLogger() {
+	config := zap.NewProductionConfig()
+	config.OutputPaths = []string{"/dev/stdout"}
+	logConfig = &config
+	logger, _ = logConfig.Build()
+	defer logger.Sync()
+	zap.ReplaceGlobals(logger)
+	zap.RedirectStdLogAt(logger, zap.InfoLevel)
+}
+
 func main() {
-	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	initializeZapLogger()
 	flagSet := flag.NewFlagSet("oauth2_proxy", flag.ExitOnError)
 
 	emailDomains := StringArray{}
@@ -22,6 +38,7 @@ func main() {
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
+	level := NewLevelFlagAt(zap.DebugLevel)
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -72,7 +89,6 @@ func main() {
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
 	flagSet.Bool("request-logging", true, "Log requests to stdout")
-	flagSet.String("request-logging-format", defaultRequestLoggingFormat, "Template for log lines")
 
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
@@ -88,10 +104,15 @@ func main() {
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
 
+	flagSet.String("http-log-path", "/dev/stdout", "Log file path for http request logs. Defaults to stdout.")
+	flagSet.String("log-path", "/dev/stdout", "Log file path for oauth2_proxy logs.")
+	flagSet.Var(&level, "log-level", "Log level to use for logging oauth2_proxy messages.")
+
 	flagSet.Parse(os.Args[1:])
 
 	if *showVersion {
-		fmt.Printf("oauth2_proxy %s (built with %s)\n", VERSION, runtime.Version())
+		logger.Info("oauth2_proxy build version",
+			zap.String("version", runtime.Version()))
 		return
 	}
 
@@ -107,11 +128,19 @@ func main() {
 	cfg.LoadEnvForStruct(opts)
 	options.Resolve(opts, flagSet, cfg)
 
+	// Update log settings from options
+	logConfig.Level.SetLevel(level.Level())
+	logConfig.OutputPaths = []string{opts.LogPath}
+	logger, _ = logConfig.Build()
+	defer logger.Sync()
+
 	err := opts.Validate()
 	if err != nil {
-		log.Printf("%s", err)
+		logger.Error("Options validation errors",
+			zap.String("errors", err.Error()))
 		os.Exit(1)
 	}
+
 	validator := NewValidator(opts.EmailDomains, opts.AuthenticatedEmailsFile)
 	oauthproxy := NewOAuthProxy(opts, validator)
 
@@ -124,16 +153,19 @@ func main() {
 	}
 
 	if opts.HtpasswdFile != "" {
-		log.Printf("using htpasswd file %s", opts.HtpasswdFile)
+		logger.Info("Using htpasswd file",
+			zap.String("htpasswdfile", opts.HtpasswdFile))
 		oauthproxy.HtpasswdFile, err = NewHtpasswdFromFile(opts.HtpasswdFile)
 		oauthproxy.DisplayHtpasswdForm = opts.DisplayHtpasswdForm
 		if err != nil {
-			log.Fatalf("FATAL: unable to open %s %s", opts.HtpasswdFile, err)
+			logger.Fatal("Unable to open htpasswdfile",
+				zap.String("htpasswdfile", opts.HtpasswdFile),
+				zap.String("error", err.Error()))
 		}
 	}
 
 	s := &Server{
-		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.RequestLoggingFormat),
+		Handler: LoggingHandler(oauthproxy, opts.RequestLogging, opts.HTTPLogPath),
 		Opts:    opts,
 	}
 	s.ListenAndServe()

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/mbland/hmacauth"
 	"github.com/pusher/oauth2_proxy/providers"
 	"github.com/stretchr/testify/assert"
@@ -22,8 +24,8 @@ import (
 )
 
 func init() {
-	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
-
+	logger, _ = zap.NewDevelopment()
+	defer logger.Sync()
 }
 
 func TestNewReverseProxy(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -87,7 +87,8 @@ type Options struct {
 	SignatureKey string    `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
 	HTTPLogPath  string    `flag:"http-log-path" cfg:"http_log_path" env:"HTTP_LOG_PATH"`
 	LogPath      string    `flag:"log-path" cfg:"log_path" env:"LOG_PATH"`
-	LevelFlag    LevelFlag `flag:"log-level" cfg:"log_level"`
+	LevelFlag    LevelFlag `flag:"log-level" cfg:"log_level" env:"LOG_LEVEL"`
+	JSONLogging  bool      `flag:"json-logging" cfg:"json-logging" env:"JSON_LOGGING"`
 
 	// internal values that are set after config validation
 	redirectURL   *url.URL
@@ -129,6 +130,7 @@ func NewOptions() *Options {
 		SkipOIDCDiscovery:   false,
 		HTTPLogPath:         "/dev/stdout",
 		LevelFlag:           NewLevelFlagAt(zap.InfoLevel),
+		JSONLogging:         false,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -16,6 +16,7 @@ import (
 	oidc "github.com/coreos/go-oidc"
 	"github.com/mbland/hmacauth"
 	"github.com/pusher/oauth2_proxy/providers"
+	"go.uber.org/zap"
 )
 
 // Options holds Configuration Options that can be set by Command Line Flag,
@@ -81,10 +82,12 @@ type Options struct {
 	Scope             string `flag:"scope" cfg:"scope"`
 	ApprovalPrompt    string `flag:"approval-prompt" cfg:"approval_prompt"`
 
-	RequestLogging       bool   `flag:"request-logging" cfg:"request_logging"`
-	RequestLoggingFormat string `flag:"request-logging-format" cfg:"request_logging_format"`
+	RequestLogging bool `flag:"request-logging" cfg:"request_logging"`
 
-	SignatureKey string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
+	SignatureKey string    `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
+	HTTPLogPath  string    `flag:"http-log-path" cfg:"http_log_path" env:"HTTP_LOG_PATH"`
+	LogPath      string    `flag:"log-path" cfg:"log_path" env:"LOG_PATH"`
+	LevelFlag    LevelFlag `flag:"log-level" cfg:"log_level"`
 
 	// internal values that are set after config validation
 	redirectURL   *url.URL
@@ -104,27 +107,28 @@ type SignatureData struct {
 // NewOptions constructs a new Options with defaulted values
 func NewOptions() *Options {
 	return &Options{
-		ProxyPrefix:          "/oauth2",
-		HTTPAddress:          "127.0.0.1:4180",
-		HTTPSAddress:         ":443",
-		DisplayHtpasswdForm:  true,
-		CookieName:           "_oauth2_proxy",
-		CookieSecure:         true,
-		CookieHTTPOnly:       true,
-		CookieExpire:         time.Duration(168) * time.Hour,
-		CookieRefresh:        time.Duration(0),
-		SetXAuthRequest:      false,
-		SkipAuthPreflight:    false,
-		PassBasicAuth:        true,
-		PassUserHeaders:      true,
-		PassAccessToken:      false,
-		PassHostHeader:       true,
-		SetAuthorization:     false,
-		PassAuthorization:    false,
-		ApprovalPrompt:       "force",
-		RequestLogging:       true,
-		SkipOIDCDiscovery:    false,
-		RequestLoggingFormat: defaultRequestLoggingFormat,
+		ProxyPrefix:         "/oauth2",
+		HTTPAddress:         "127.0.0.1:4180",
+		HTTPSAddress:        ":443",
+		DisplayHtpasswdForm: true,
+		CookieName:          "_oauth2_proxy",
+		CookieSecure:        true,
+		CookieHTTPOnly:      true,
+		CookieExpire:        time.Duration(168) * time.Hour,
+		CookieRefresh:       time.Duration(0),
+		SetXAuthRequest:     false,
+		SkipAuthPreflight:   false,
+		PassBasicAuth:       true,
+		PassUserHeaders:     true,
+		PassAccessToken:     false,
+		PassHostHeader:      true,
+		SetAuthorization:    false,
+		PassAuthorization:   false,
+		ApprovalPrompt:      "force",
+		RequestLogging:      true,
+		SkipOIDCDiscovery:   false,
+		HTTPLogPath:         "/dev/stdout",
+		LevelFlag:           NewLevelFlagAt(zap.InfoLevel),
 	}
 }
 
@@ -164,6 +168,8 @@ func (o *Options) Validate() error {
 	}
 
 	if o.OIDCIssuerURL != "" {
+		logger.Info("Validing OIDC Issuer URL",
+			zap.String("oidc_issuer_url", o.OIDCIssuerURL))
 
 		ctx := context.Background()
 
@@ -172,6 +178,7 @@ func (o *Options) Validate() error {
 		// In this case we need to make sure the required endpoints for
 		// the provider are configured.
 		if o.SkipOIDCDiscovery {
+			logger.Info("Skipping OIDC Discovery")
 			if o.LoginURL == "" {
 				msgs = append(msgs, "missing setting: login-url")
 			}
@@ -189,6 +196,9 @@ func (o *Options) Validate() error {
 			// Configure discoverable provider data.
 			provider, err := oidc.NewProvider(ctx, o.OIDCIssuerURL)
 			if err != nil {
+				logger.Fatal("Unable to create new OIDC provider",
+					zap.String("oidc_issuer_url", o.OIDCIssuerURL),
+					zap.String("err", err.Error()))
 				return err
 			}
 			o.oidcVerifier = provider.Verifier(&oidc.Config{
@@ -197,10 +207,18 @@ func (o *Options) Validate() error {
 
 			o.LoginURL = provider.Endpoint().AuthURL
 			o.RedeemURL = provider.Endpoint().TokenURL
+
+			logger.Debug("Discovered OIDC configuration",
+				zap.String("oidc_issuer_url", o.OIDCIssuerURL),
+				zap.String("AuthURL", provider.Endpoint().AuthURL),
+				zap.String("TokenURL", provider.Endpoint().TokenURL))
 		}
+
 		if o.Scope == "" {
 			o.Scope = "openid email profile"
 		}
+		logger.Info("Configured OIDC scopes",
+			zap.String("scopes", o.Scope))
 	}
 
 	o.redirectURL, msgs = parseURL(o.RedirectURL, "redirect", msgs)


### PR DESCRIPTION
Uses Zap to provide configurable and structured logging support.

## Description

All logging is changed to use structured logging in `json`. Zap library is used for this purpose and it is extremely light and fast. Program and request logs are now separated, though defaulted to `stdout`. The log level is defaulted to `info`, and is configurable.

Issue #90 for more information.

## Motivation and Context

Most enterprises aggregate logs into tools like splunk, elastic, etc so they can be processed further. This PR switches to structured logging, so log ingestion in to these tools becomes extremely easy.

## How Has This Been Tested?

Unit tests are added to test the ability to write the log to a file. Unit tests added to test log-level configuration.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ X] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
