### PR TITLE
GKE Ingress Health Check middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - 1.10.x
   - 1.11.x
+  - 1.12.x
 install:
   # Fetch dependencies
   - wget -O dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/mreiferson/go-options"
+	"github.com/pusher/oauth2_proxy/middleware"
 )
 
 func main() {
@@ -132,8 +133,11 @@ func main() {
 		}
 	}
 
+	h := LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.RequestLoggingFormat)
+	wrappedHandler := middleware.IngressHealthCheck(h, func() error { return nil })
+
 	s := &Server{
-		Handler: LoggingHandler(os.Stdout, oauthproxy, opts.RequestLogging, opts.RequestLoggingFormat),
+		Handler: wrappedHandler,
 		Opts:    opts,
 	}
 	s.ListenAndServe()

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+const userAgentHeader = "User-Agent"
+const googleHealthCheckUserAgent = "GoogleHC/1.0"
+const rootPath = "/"
+
+// IngressHealthCheck is a middleware that is designed to be used with the Ingress in GKE. The ingress requires the root
+// path of the target to return a 200 (OK) to indicate the service's good health. This can be quite a challenging demand
+// depending on the application's path structure. This middleware filters out the requests from the health check by
+//
+// 1. checking that the request path is indeed the root path
+// 2. ensuring that the User-Agent is "GoogleHC/1.0", the health checker
+// 3. ensuring the request method is "GET"
+//
+// The ping can be used to indicate the health of the service. Like the sql package implementation, if it returns an
+// error, the middleware will return a unhealthy response by returning a 500 (Internal). Otherwise if healthy, it
+// returns a 200 (OK).
+//
+// An error that causes an "unhealthy" is not returned to the health check for security purposes.
+func IngressHealthCheck(next http.Handler, ping func() error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == rootPath &&
+			r.Header.Get(userAgentHeader) == googleHealthCheckUserAgent &&
+			r.Method == http.MethodGet {
+			if err := ping(); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -1,0 +1,145 @@
+package middleware_test
+
+import (
+	"errors"
+	"github.com/tumelohq/gke-ingress-healthcheck-middleware"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIngressHealthCheck(t *testing.T) {
+	t.Parallel()
+	tts := []struct {
+		name       string
+		ping       func() error
+		handler    http.Handler
+		path       string
+		header     http.Header
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name: "non health check request, root",
+			ping: func() error { return nil },
+			handler: func() http.Handler {
+				h := http.NewServeMux()
+				h.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusBadRequest)
+				})
+				return h
+			}(),
+			path:       "/",
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "",
+		},
+		{
+			name: "non health check request, non root",
+			ping: func() error { return nil },
+			handler: func() http.Handler {
+				h := http.NewServeMux()
+				h.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusBadRequest)
+				})
+				return h
+			}(),
+			path:       "/test",
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "",
+		},
+		{
+			name: "health check, healthy",
+			ping: func() error { return nil },
+			handler: func() http.Handler {
+				h := http.NewServeMux()
+				h.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusBadRequest)
+				})
+				return h
+			}(),
+			path: "/",
+			header: func() http.Header {
+				h := http.Header{}
+				h.Set("User-Agent", "GoogleHC/1.0")
+				return h
+			}(),
+			wantStatus: http.StatusOK,
+			wantBody:   "",
+		},
+		{
+			name: "health check, not healthy",
+			ping: func() error { return errors.New("test") },
+			handler: func() http.Handler {
+				h := http.NewServeMux()
+				h.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusBadRequest)
+				})
+				return h
+			}(),
+			path: "/",
+			header: func() http.Header {
+				h := http.Header{}
+				h.Set("User-Agent", "GoogleHC/1.0")
+				return h
+			}(),
+			wantStatus: http.StatusInternalServerError,
+			wantBody:   "",
+		},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// setup
+			s := httptest.NewServer(middleware.IngressHealthCheck(tt.handler, tt.ping))
+			defer s.Close()
+			r, err := http.NewRequest(http.MethodGet, s.URL+tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r.Header = tt.header
+
+			// do
+			res, err := s.Client().Do(r)
+			if err != nil {
+				t.Fatalf("get: %s", err)
+			}
+
+			// check
+			if res.StatusCode != tt.wantStatus {
+				t.Errorf("want status code %d, got %d", tt.wantStatus, res.StatusCode)
+			}
+			bodyBytes, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			b := string(bodyBytes)
+			if b != "" {
+				t.Error("non-empty body")
+			}
+		})
+	}
+}
+
+func ExampleIngressHealthCheck() {
+	// Handler
+	h := http.NewServeMux()
+	h.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	// Sample ping Function
+	ping := func() error {
+		if rand.Int31n(100) > 50 {
+			return errors.New("test error")
+		}
+		return nil
+	}
+
+	// Middleware
+	wrapped := middleware.IngressHealthCheck(h, ping)
+
+	// Serve
+	log.Fatal(http.ListenAndServe("localhost:3030", wrapped))
+}

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -2,7 +2,7 @@ package middleware_test
 
 import (
 	"errors"
-	"github.com/tumelohq/gke-ingress-healthcheck-middleware"
+	"github.com/pusher/oauth2_proxy/middleware"
 	"io/ioutil"
 	"log"
 	"math/rand"


### PR DESCRIPTION
The ingress requires the root path of the target to return a 200 (OK) to
indicate the service's good health. The middleware handles the specific
health check call.

## Description

This change adds the middle ware required to handle that specific call. 

## Motivation and Context

This is required to run the proxy smoothly on GKE

## How Has This Been Tested?

The code has been tested and it has been tested on our clusters.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
