### PR TITLE
Restore proper OAuthCallbackPath path

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -241,7 +241,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		SignInPath:        fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
 		SignOutPath:       fmt.Sprintf("%s/sign_out", opts.ProxyPrefix),
 		OAuthStartPath:    fmt.Sprintf("%s/start", opts.ProxyPrefix),
-		OAuthCallbackPath: redirectURL.Path,
+		OAuthCallbackPath: fmt.Sprintf("%s/callback", opts.ProxyPrefix),
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 
 		ProxyPrefix:        opts.ProxyPrefix,


### PR DESCRIPTION
## Description

The internal routing of OAuthCallbackPath should still be based on the ProxyPrefix, not the externally exposed redirectURL.

This rolls back and incorrect change from PR #10 

## Motivation and Context

The ability to return a custom redirectURL is great, especially in cases where clients intend to route traffic to oauth2_proxy via some unknown path (e.g. when oauth2_proxy is used behind an ingress).

But when the callback reaches oauth2_proxy, it should be expected on whatever path is specified by the proxy prefix. (In the ingress example, the ingress would be responsible for rewriting all paths sent to oauth2_proxy, including the callback.)

## How Has This Been Tested?

Using oauth2_proxy as the "sidecar" to an nginx proxy configured with the auth_request module, behind an Istio ingress in an Kubernetes cluster. (All the things.)

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.

I believe this change requires no updates to the CHANGELOG since it's fixing a bug from an unreleased PR.