### PR TITLE
Added pagination support for /user/teams github api

### DIFF
--- a/providers/github.go
+++ b/providers/github.go
@@ -137,36 +137,56 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 		} `json:"organization"`
 	}
 
-	params := url.Values{
-		"limit": {"200"},
+	type teamsPage []struct {
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+		Org  struct {
+			Login string `json:"login"`
+		} `json:"organization"`
 	}
 
-	endpoint := &url.URL{
-		Scheme:   p.ValidateURL.Scheme,
-		Host:     p.ValidateURL.Host,
-		Path:     path.Join(p.ValidateURL.Path, "/user/teams"),
-		RawQuery: params.Encode(),
-	}
-	req, _ := http.NewRequest("GET", endpoint.String(), nil)
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("Authorization", fmt.Sprintf("token %s", accessToken))
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return false, err
-	}
+	pn := 1
+	for {
+		params := url.Values{
+			"limit": {"200"},
+			"page":  {strconv.Itoa(pn)},
+		}
 
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return false, err
-	}
-	if resp.StatusCode != 200 {
-		return false, fmt.Errorf(
-			"got %d from %q %s", resp.StatusCode, endpoint.String(), body)
-	}
+		endpoint := &url.URL{
+			Scheme:   p.ValidateURL.Scheme,
+			Host:     p.ValidateURL.Host,
+			Path:     path.Join(p.ValidateURL.Path, "/user/teams"),
+			RawQuery: params.Encode(),
+		}
 
-	if err := json.Unmarshal(body, &teams); err != nil {
-		return false, fmt.Errorf("%s unmarshaling %s", err, body)
+		req, _ := http.NewRequest("GET", endpoint.String(), nil)
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", accessToken))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false, err
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return false, err
+		}
+		if resp.StatusCode != 200 {
+			return false, fmt.Errorf(
+				"got %d from %q %s", resp.StatusCode, endpoint.String(), body)
+		}
+
+		var tp teamsPage
+		if err := json.Unmarshal(body, &tp); err != nil {
+			return false, fmt.Errorf("%s unmarshaling %s", err, body)
+		}
+		if len(tp) == 0 {
+			break
+		}
+
+		teams = append(teams, tp...)
+		pn++
 	}
 
 	var hasOrg bool

--- a/providers/github.go
+++ b/providers/github.go
@@ -73,7 +73,7 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 	pn := 1
 	for {
 		params := url.Values{
-			"per_page": {"200"},
+			"per_page": {"100"},
 			"page":     {strconv.Itoa(pn)},
 		}
 
@@ -148,7 +148,7 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 	pn := 1
 	for {
 		params := url.Values{
-			"per_page": {"200"},
+			"per_page": {"100"},
 			"page":     {strconv.Itoa(pn)},
 		}
 

--- a/providers/github.go
+++ b/providers/github.go
@@ -73,8 +73,8 @@ func (p *GitHubProvider) hasOrg(accessToken string) (bool, error) {
 	pn := 1
 	for {
 		params := url.Values{
-			"limit": {"200"},
-			"page":  {strconv.Itoa(pn)},
+			"per_page": {"200"},
+			"page":     {strconv.Itoa(pn)},
 		}
 
 		endpoint := &url.URL{
@@ -148,8 +148,8 @@ func (p *GitHubProvider) hasOrgAndTeam(accessToken string) (bool, error) {
 	pn := 1
 	for {
 		params := url.Values{
-			"limit": {"200"},
-			"page":  {strconv.Itoa(pn)},
+			"per_page": {"200"},
+			"page":     {strconv.Itoa(pn)},
 		}
 
 		endpoint := &url.URL{

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -31,7 +31,7 @@ func testGitHubBackend(payload []string) *httptest.Server {
 	pathToQueryMap := map[string][]string{
 		"/user":        {""},
 		"/user/emails": {""},
-		"/user/orgs":   {"page=1&per_page=200", "page=2&per_page=200", "page=3&per_page=200"},
+		"/user/orgs":   {"page=1&per_page=100", "page=2&per_page=100", "page=3&per_page=100"},
 	}
 
 	return httptest.NewServer(http.HandlerFunc(

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -31,7 +31,7 @@ func testGitHubBackend(payload []string) *httptest.Server {
 	pathToQueryMap := map[string][]string{
 		"/user":        {""},
 		"/user/emails": {""},
-		"/user/orgs":   {"limit=200&page=1", "limit=200&page=2", "limit=200&page=3"},
+		"/user/orgs":   {"page=1&per_page=200", "page=2&per_page=200", "page=3&per_page=200"},
 	}
 
 	return httptest.NewServer(http.HandlerFunc(


### PR DESCRIPTION
## Description

Added pagination support for /user/teams github api

## Motivation and Context

When we are configuring both github org/team, then we are using /user/teams github api to find out if user is part of that github org/team. If user is part of more than 30 teams then the api response for /user/teams github api will be paginated across multiple pages. By adding pagination support we are checking user across all the teams.

## How Has This Been Tested?

Configure the service by setting the needed parameters that include:
- redirect-url
- github-org
- github-team
- client-id
- client-secret
- authenticated-emails-file
- cookie-secret
- cookie-domain
- cookie-secure
- provider
- login-url
- redeem-url
- validate-url

Launch the service in your IDE.

Hit the endpoint, http://localhost:4180

Login in using the sign in page

Before this change, it would return 403 permission denied, invalid account error message in browser

After this change, it would work fine and does not return any error. Logs also show that user is part of github org/team

Note: User who is part of more than 30 github team will face this issue.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
