### PR TITLE
Removed email_verified claim handling from OIDC_provider to prevent parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Changes since v3.1.0
 
 - [#68](https://github.com/pusher/oauth2_proxy/pull/68) forward X-Auth-Access-Token header (@davidholsgrove)
-- [#41](https://github.com/pusher/oauth2_proxy/pull/41) Added option to manually specify OIDC endpoints instead of relying on discovery
 
 # v3.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
 COPY . .
 
 # Fetch dependencies
-RUN dep ensure --vendor-only
+RUN dep ensure
 
 # Build binary
 RUN ./configure && make build

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,7 +13,7 @@
 
 [[constraint]]
   branch = "v2"
-  name = "github.com/coreos/go-oidc"
+  name = "github.com/MXClyde/go-oidc"
 
 [[constraint]]
   branch = "master"

--- a/README.md
+++ b/README.md
@@ -166,26 +166,6 @@ OpenID Connect is a spec for OAUTH 2.0 + identity that is implemented by many ma
     -cookie-secure=false
     -email-domain example.com
 
-#### Skip OIDC discovery
-
-Some providers do not support OIDC discovery via their issuer URL, so oauth2_proxy cannot simply grab the authorization, token and jwks URI endpoints from the provider's metadata.
-
-In this case, you can set the `-skip-oidc-discovery` option, and supply those required endpoints manually:
-
-```
-    -provider oidc
-    -client-id oauth2_proxy
-    -client-secret proxy
-    -redirect-url http://127.0.0.1:4180/oauth2/callback
-    -oidc-issuer-url http://127.0.0.1:5556
-    -skip-oidc-discovery
-    -login-url http://127.0.0.1:5556/authorize
-    -redeem-url http://127.0.0.1:5556/token
-    -oidc-jwks-url http://127.0.0.1:5556/keys
-    -cookie-secure=false
-    -email-domain example.com
-```
-
 ## Email Authentication
 
 To authorize by email domain use `--email-domain=yourcompany.com`. To authorize individual email addresses use `--authenticated-emails-file=/path/to/file` with one email per line. To authorize all email addresses use `--email-domain=*`.
@@ -233,7 +213,6 @@ Usage of oauth2_proxy:
   -https-address string: <addr>:<port> to listen on for HTTPS clients (default ":443")
   -login-url string: Authentication endpoint
   -oidc-issuer-url: the OpenID Connect issuer URL. ie: "https://accounts.google.com"
-  -oidc-jwks-url string: OIDC JWKS URI for token verification; required if OIDC discovery is disabled
   -pass-access-token: pass OAuth access_token to upstream via X-Forwarded-Access-Token header
   -pass-authorization-header: pass OIDC IDToken to upstream via Authorization Bearer header
   -pass-basic-auth: pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream (default true)
@@ -253,7 +232,6 @@ Usage of oauth2_proxy:
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
   -skip-auth-preflight: will skip authentication for OPTIONS requests
   -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)
-  -skip-oidc-discovery: bypass OIDC endpoint discovery. login-url, redeem-url and oidc-jwks-url must be configured in this case
   -skip-provider-button: will skip sign-in-page to directly reach the next step: oauth/start
   -ssl-insecure-skip-verify: skip validation of certificates presented when using HTTPS
   -tls-cert string: path to certificate file

--- a/main.go
+++ b/main.go
@@ -76,8 +76,6 @@ func main() {
 
 	flagSet.String("provider", "google", "OAuth provider")
 	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
-	flagSet.Bool("skip-oidc-discovery", false, "Skip OIDC discovery and use manually supplied Endpoints")
-	flagSet.String("oidc-jwks-url", "", "OpenID Connect JWKS URL (ie: https://www.googleapis.com/oauth2/v3/certs)")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")

--- a/options.go
+++ b/options.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	oidc "github.com/coreos/go-oidc"
+	oidc "github.com/MXClyde/go-oidc"
 	"github.com/mbland/hmacauth"
 	"github.com/pusher/oauth2_proxy/providers"
 )

--- a/options_test.go
+++ b/options_test.go
@@ -251,20 +251,3 @@ func TestValidateCookieBadName(t *testing.T) {
 	assert.Equal(t, err.Error(), "Invalid configuration:\n"+
 		fmt.Sprintf("  invalid cookie name: %q", o.CookieName))
 }
-
-func TestSkipOIDCDiscovery(t *testing.T) {
-	o := testOptions()
-	o.Provider = "oidc"
-	o.OIDCIssuerURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/v2.0/"
-	o.SkipOIDCDiscovery = true
-
-	err := o.Validate()
-	assert.Equal(t, "Invalid configuration:\n"+
-		fmt.Sprintf("  missing setting: login-url\n  missing setting: redeem-url\n  missing setting: oidc-jwks-url"), err.Error())
-
-	o.LoginURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_sign_in"
-	o.RedeemURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/token?p=b2c_1_sign_in"
-	o.OIDCJwksURL = "https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/discovery/v2.0/keys"
-
-	assert.Equal(t, nil, o.Validate())
-}

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -7,7 +7,7 @@ import (
 
 	"golang.org/x/oauth2"
 
-	oidc "github.com/coreos/go-oidc"
+	oidc "github.com/MXClyde/go-oidc"
 )
 
 // OIDCProvider represents an OIDC based Identity Provider
@@ -106,16 +106,16 @@ func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Tok
 
 	// Extract custom claims.
 	var claims struct {
-		Email    string `json:"email"`
+		Email    string `json:"sub"`
 	//	Verified string `json:"email_verified"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("failed to parse id_token claims: %v", err)
 	}
 
-	if claims.Email == "" {
-		return nil, fmt.Errorf("id_token did not contain an email")
-	}
+	//if claims.Email == "" {
+	//	return nil, fmt.Errorf("id_token did not contain an email")
+	//}
 	//if claims.Verified != nil && !*claims.Verified {
 	//	return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
 	//}

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -106,19 +106,24 @@ func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Tok
 
 	// Extract custom claims.
 	var claims struct {
+<<<<<<< HEAD
 		Email    string `json:"sub"`
 	//	Verified string `json:"email_verified"`
+=======
+		Email    string `json:"email"`
+		Verified *bool  `json:"email_verified"`
+>>>>>>> parent of 3ecb7d9... Ensured string variable for OIDC provider also works
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("failed to parse id_token claims: %v", err)
 	}
 
-	//if claims.Email == "" {
-	//	return nil, fmt.Errorf("id_token did not contain an email")
-	//}
-	//if claims.Verified != nil && !*claims.Verified {
-	//	return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
-	//}
+	if claims.Email == "" {
+		return nil, fmt.Errorf("id_token did not contain an email")
+	}
+	if claims.Verified != nil && !*claims.Verified {
+		return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
+	}
 
 	return &SessionState{
 		AccessToken:  token.AccessToken,

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -107,15 +107,15 @@ func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Tok
 	// Extract custom claims.
 	var claims struct {
 		Email    string `json:"email"`
-		Verified string `json:"email_verified"`
+	//	Verified string `json:"email_verified"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("failed to parse id_token claims: %v", err)
 	}
 
-	//if claims.Email == "" {
-	//	return nil, fmt.Errorf("id_token did not contain an email")
-	//}
+	if claims.Email == "" {
+		return nil, fmt.Errorf("id_token did not contain an email")
+	}
 	//if claims.Verified != nil && !*claims.Verified {
 	//	return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
 	//}

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -107,18 +107,18 @@ func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Tok
 	// Extract custom claims.
 	var claims struct {
 		Email    string `json:"email"`
-		Verified *bool  `json:"email_verified"`
+		Verified string `json:"email_verified"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("failed to parse id_token claims: %v", err)
 	}
 
-	if claims.Email == "" {
-		return nil, fmt.Errorf("id_token did not contain an email")
-	}
-	if claims.Verified != nil && !*claims.Verified {
-		return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
-	}
+	//if claims.Email == "" {
+	//	return nil, fmt.Errorf("id_token did not contain an email")
+	//}
+	//if claims.Verified != nil && !*claims.Verified {
+	//	return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
+	//}
 
 	return &SessionState{
 		AccessToken:  token.AccessToken,


### PR DESCRIPTION
Removed email_verified claim handling from OIDC_provider to prevent "failed to parse id_token claims: json: cannot unmarshal string into Go struct field .email_verified of type bool" error.

## Description

Removed the parsing and verification of email_verified claim.

## Motivation and Context

My ID token (as passed by [Centrify](https://www.centrify.com) IdP) is as follows: 

```
{
  "preferred_username": "User.Name@company.com",
  "unique_name": "User.Name@company.coml",
  "email": "User.Name@company.coml",
  "email_verified": "true",
  "iat": 111111111111111,
  "sub": "111111111-26d5-4606-a04f-5ecndjjnnjn5",
  "exp": 1552488265,
  "scope": "openid email address profile",
  "aud": "1111111111-11b0-456b-9b44-e48b337045e7",
  "nonce": "111111111-zC80vbhgNdTDz2vQyk",
  "iss": "https://company/Test/",
  "name": "User Name",
  "phone_number": ""
}
```

Parsing this leads to the following error in oauth2_proxy logs:

```
2019/03/04 15:05:52 oauthproxy.go:715: 10.244.1.79:52794 ("10.244.1.1") error redeeming code unable to update session: failed to parse id_token claims: json: cannot unmarshal string into Go struct field .email_verified of type bool
2019/03/04 15:05:52 oauthproxy.go:498: ErrorPage 500 Internal Error Internal Error
```

I suspect there is a problem with parsing email_verified. However, since my knowledge of Go is too limited to resolve this, I just removed the whole validation of email_verified. This should probably be done a little less rigorous ;-)

## How Has This Been Tested?

OAuth2_proxy works properly against Centrify now that this has been changed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
