### PR TITLE
Implement Getter interface for StringArray

### DIFF
--- a/string_array.go
+++ b/string_array.go
@@ -7,6 +7,11 @@ import (
 // StringArray is a type alias for a slice of strings
 type StringArray []string
 
+// Get returns the slice of strings
+func (a *StringArray) Get() interface{} {
+	return []string(*a)
+}
+
 // Set appends a string to the StringArray
 func (a *StringArray) Set(s string) error {
 	*a = append(*a, s)


### PR DESCRIPTION
This commit fix the issue #98

<!--- Provide a general summary of your changes in the Title above -->

## Description

Implement the Getter interface for StringArray to be able to use the last version of go-options.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This MR fix the issue #98.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I rebuild the docker image and use it in my previous docker-compose setup which worked before this issue #98.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
