### PR TITLE
Set redirect URL path when host is present

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -204,7 +204,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 	}
 
 	redirectURL := opts.redirectURL
-	if redirectURL.String() == "" {
+	if redirectURL.Path == "" {
 		redirectURL.Path = fmt.Sprintf("%s/callback", opts.ProxyPrefix)
 	}
 


### PR DESCRIPTION
## Description

Add the default redirect path when the provided redirect URL contains a host but not a path.

## Motivation and Context

This was a regression introduced in #10. A similar change was made in https://github.com/ploxiln/oauth2_proxy/pull/29. 
