### PR TITLE
build: use go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.10.x
   - 1.11.x
+  - 1.12.x
 install:
   # Fetch dependencies
   - wget -O dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#83](https://github.com/pusher/oauth2_proxy/pull/83) Add `id_token` refresh to Google provider (@leki75)
 - [#10](https://github.com/pusher/oauth2_proxy/pull/10) fix redirect url param handling (@dt-rush)
 - [#122](https://github.com/pusher/oauth2_proxy/pull/122) Expose -cookie-path as configuration parameter (@costelmoraru)
+- [#124](https://github.com/pusher/oauth2_proxy/pull/124) Use Go 1.12 for testing and build environments (@syscll)
 
 # v3.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-stretch AS builder
+FROM golang:1.12-stretch AS builder
 
 # Download tools
 RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64

--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ check_for() {
 check_go_version() {
   echo -n "Checking go version... "
   GO_VERSION=$(${tools[go]} version | ${tools[awk]} '{where = match($0, /[0-9]\.[0-9]+\.[0-9]*/); if (where != 0) print substr($0, RSTART, RLENGTH)}')
-  vercomp $GO_VERSION 1.10
+  vercomp $GO_VERSION 1.11
   case $? in
     0) ;&
     1)
@@ -91,7 +91,7 @@ check_go_version() {
       ;;
     2)
       printf "${RED}"
-      echo "$GO_VERSION < 1.10"
+      echo "$GO_VERSION < 1.11"
       exit 1
       ;;
   esac


### PR DESCRIPTION
## Description
- Upgraded Go version for Docker and Travis builds to 1.12
- Removed Go version 1.10 from Travis CI environment.

## Motivation and Context
- Go 1.12 is the current minor release therefore this upgrade is recommended.

## How Has This Been Tested?
- Successfully built locally.
- Successfully built on Travis CI environment.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
