### PR TITLE
Server Cookies Store, with Redis implementation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -51,6 +51,22 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:edab2b668c427fadca75b629ba1cba5a759893cfc734a7210a2a26745e0a86ac"
+  name = "github.com/go-redis/redis"
+  packages = [
+    ".",
+    "internal",
+    "internal/consistenthash",
+    "internal/hashtag",
+    "internal/pool",
+    "internal/proto",
+    "internal/util",
+  ]
+  pruneopts = ""
+  revision = "4b1665dfdc17efd2d1f450a6661a472d121364b1"
+
+[[projects]]
+  branch = "master"
   digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
@@ -218,6 +234,7 @@
     "github.com/bitly/go-simplejson",
     "github.com/coreos/go-oidc",
     "github.com/dgrijalva/jwt-go",
+    "github.com/go-redis/redis",
     "github.com/mbland/hmacauth",
     "github.com/mreiferson/go-options",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,25 @@
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:3cce78d5d0090e3f1162945fba60ba74e72e8422e8e41bb9c701afb67237bb65"
+  name = "github.com/alicebob/gopher-json"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5a6b3ba71ee69b77cf64febf8b5a7526ca5eaef0"
+
+[[projects]]
+  digest = "1:18a07506ddaa87b1612bfd69eef03f510faf122398df3da774d46dcfe751a060"
+  name = "github.com/alicebob/miniredis"
+  packages = [
+    ".",
+    "server",
+  ]
+  pruneopts = ""
+  revision = "3d7aa1333af56ab862d446678d93aaa6803e0938"
+  version = "v2.7.0"
+
+[[projects]]
   digest = "1:512883404c2a99156e410e9880e3bb35ecccc0c07c1159eb204b5f3ef3c431b3"
   name = "github.com/bitly/go-simplejson"
   packages = ["."]
@@ -74,6 +93,17 @@
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
+  digest = "1:dcf8316121302735c0ac84e05f4686e3b34e284444435e9a206da48d8be18cb1"
+  name = "github.com/gomodule/redigo"
+  packages = [
+    "internal",
+    "redis",
+  ]
+  pruneopts = ""
+  revision = "9c11da706d9b7902c6da69c592f75637793fe121"
+  version = "v2.0.0"
+
+[[projects]]
   digest = "1:af67386ca553c04c6222f7b5b2f17bc97a5dfb3b81b706882c7fd8c72c30cf8f"
   name = "github.com/mbland/hmacauth"
   packages = ["."]
@@ -126,6 +156,19 @@
   packages = ["."]
   pruneopts = ""
   revision = "1d66fa95c997864ba4d8479f56609620fe542928"
+
+[[projects]]
+  branch = "master"
+  digest = "1:378d29a839ff770e9d9150580b4c01ff0a513a296b0487558a7af7c18adab98e"
+  name = "github.com/yuin/gopher-lua"
+  packages = [
+    ".",
+    "ast",
+    "parse",
+    "pm",
+  ]
+  pruneopts = ""
+  revision = "8bfc7677f583b35a5663a9dd934c08f3b5774bbb"
 
 [[projects]]
   branch = "master"
@@ -231,6 +274,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
+    "github.com/alicebob/miniredis",
     "github.com/bitly/go-simplejson",
     "github.com/coreos/go-oidc",
     "github.com/dgrijalva/jwt-go",
@@ -248,6 +292,7 @@
     "google.golang.org/api/googleapi",
     "gopkg.in/fsnotify/fsnotify.v1",
     "gopkg.in/natefinch/lumberjack.v2",
+    "gopkg.in/square/go-jose.v2",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,6 +17,10 @@
 
 [[constraint]]
   branch = "master"
+  name = "github.com/go-redis/redis"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/mreiferson/go-options"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,3 +46,7 @@
 [[constraint]]
   name = "gopkg.in/natefinch/lumberjack.v2"
   version = "2.1.0"
+
+[[constraint]]
+  name = "github.com/alicebob/miniredis"
+  version = "2.7.0"

--- a/cookie/cookies_store.go
+++ b/cookie/cookies_store.go
@@ -1,0 +1,153 @@
+package cookie
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-redis/redis"
+)
+
+// ServerCookiesStore is the interface to storing cookies.
+// It takes in cookies
+type ServerCookiesStore interface {
+	Store(responseCookie *http.Cookie, requestCookie *http.Cookie) (string, error)
+	Clear(requestCookie *http.Cookie) (bool, error)
+	Load(requestCookie *http.Cookie) (string, error)
+}
+
+// RedisCookieStore is an Redis-backed implementation of a ServerCookiesStore.
+// It stores the cookies according to the cookie ticket, which is composed of
+// a Prefix (the same as the CookieName) and a handle (a random identifier)
+type RedisCookieStore struct {
+	Client *redis.Client
+	Block  cipher.Block
+	Prefix string
+}
+
+// NewRedisCookieStore constructs a new Redis-backed Server cookie store.
+func NewRedisCookieStore(url string, cookieName string, block cipher.Block) (*RedisCookieStore, error) {
+	opt, err := redis.ParseURL(url)
+	if err != nil {
+		panic(err)
+	}
+
+	client := redis.NewClient(opt)
+
+	rs := &RedisCookieStore{
+		Client: client,
+		Prefix: cookieName,
+		Block:  block,
+	}
+	// Create client as usually.
+	return rs, nil
+}
+
+// Store stores the cookie locally and returns a new response cookie value to be
+// sent back to the client. That value is used to lookup the cookie later.
+func (store *RedisCookieStore) Store(responseCookie *http.Cookie, requestCookie *http.Cookie) (string, error) {
+	var cookieHandle string
+	var iv []byte
+	if requestCookie != nil {
+		var err error
+		cookieHandle, iv, err = parseCookieTicket(store.Prefix, requestCookie.Value)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		hasher := sha1.New()
+		hasher.Write([]byte(responseCookie.Value))
+		cookieID := fmt.Sprintf("%x", hasher.Sum(nil))
+		iv = make([]byte, aes.BlockSize)
+		if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+			return "", fmt.Errorf("failed to create initialization vector %s", err)
+		}
+		cookieHandle = fmt.Sprintf("%s-%s", store.Prefix, cookieID)
+	}
+
+	ciphertext := make([]byte, len(responseCookie.Value))
+	stream := cipher.NewCFBEncrypter(store.Block, iv)
+	stream.XORKeyStream(ciphertext, []byte(responseCookie.Value))
+
+	expires := responseCookie.Expires.Sub(time.Now())
+	err := store.Client.Set(cookieHandle, ciphertext, expires).Err()
+	if err != nil {
+		return "", err
+	}
+
+	cookieTicket := cookieHandle + "." + base64.RawURLEncoding.EncodeToString(iv)
+	return cookieTicket, nil
+}
+
+// Clear takes in the client cookie from the request and uses it to
+// clear any lingering server cookies, when possible. It returns true if anything
+// was deleted.
+func (store *RedisCookieStore) Clear(requestCookie *http.Cookie) (bool, error) {
+	var err error
+	cookieHandle, _, err := parseCookieTicket(store.Prefix, requestCookie.Value)
+	if err != nil {
+		return false, err
+	}
+
+	deleted, err := store.Client.Del(cookieHandle).Result()
+	if err != nil {
+		return false, err
+	}
+	return deleted > 0, nil
+}
+
+// Load takes in the client cookie from the request and uses it to lookup
+// the stored value.
+func (store *RedisCookieStore) Load(requestCookie *http.Cookie) (string, error) {
+	cookieHandle, iv, err := parseCookieTicket(store.Prefix, requestCookie.Value)
+	if err != nil {
+		return "", err
+	}
+
+	result, err := store.Client.Get(cookieHandle).Result()
+	if err != nil {
+		return "", err
+	}
+
+	resultBytes := []byte(result)
+
+	stream := cipher.NewCFBDecrypter(store.Block, iv)
+	stream.XORKeyStream(resultBytes, resultBytes)
+	return string(resultBytes), nil
+}
+
+func parseCookieTicket(cookieName string, ticket string) (string, []byte, error) {
+	prefix := cookieName + "-"
+	if !strings.HasPrefix(ticket, prefix) {
+		return "", nil, fmt.Errorf("failed to decode cookie handle")
+	}
+	trimmedTicket := strings.TrimPrefix(ticket, prefix)
+
+	cookieParts := strings.Split(trimmedTicket, ".")
+	if len(cookieParts) != 2 {
+		return "", nil, fmt.Errorf("failed to decode cookie")
+	}
+	cookieID, ivBase64 := cookieParts[0], cookieParts[1]
+	cookieHandle := prefix + cookieID
+
+	// cookieID must be a hexadecimal string
+	_, err := hex.DecodeString(cookieID)
+	if err != nil {
+		return "", nil, fmt.Errorf("server cookie failed sanity checks")
+		// s is not a valid
+	}
+
+	iv, err := base64.RawURLEncoding.DecodeString(ivBase64)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to decode initialization vector %s", err)
+	}
+	return cookieHandle, iv, nil
+}

--- a/cookie/cookies_store_test.go
+++ b/cookie/cookies_store_test.go
@@ -1,0 +1,180 @@
+package cookie
+
+import (
+	"encoding/base64"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/alicebob/miniredis"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+func NewTestRedis() *redis.Client {
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	client.Ping()
+	return client
+}
+
+func TestRedisCookieStore(t *testing.T) {
+	client := NewTestRedis()
+	secretString, _ := base64.RawURLEncoding.DecodeString("MTIzNDU2Nzg5MDEyMzQ1Ng")
+	testCipher, _ := NewCipher(secretString)
+
+	firstValue := "1234567890"
+	responseCookie := &http.Cookie{Value: firstValue}
+
+	store := &RedisCookieStore{
+		Client: client,
+		Block:  testCipher.Block,
+		Prefix: "oauth2_proxy",
+	}
+
+	// Test Store
+	ticket, err := store.Store(responseCookie, nil)
+	if err != nil {
+		t.Errorf("RedisCookieStore.Store() error = %v", err)
+		return
+	}
+
+	// Test Load
+	ticketCookie := &http.Cookie{Value: ticket}
+	loadedValue, err := store.Load(ticketCookie)
+	if err != nil {
+		t.Errorf("RedisCookieStore.Load() error = %v", err)
+		return
+	}
+
+	if loadedValue != firstValue {
+		t.Errorf("RedisCookieStore.Store() = %v, expected %v", loadedValue, firstValue)
+	}
+
+	// Test replacement
+	secondValue := "0987654321"
+	responseCookie = &http.Cookie{Value: secondValue}
+
+	_, err = store.Store(responseCookie, ticketCookie)
+	if err != nil {
+		t.Errorf("RedisCookieStore.Store() error = %v", err)
+		return
+	}
+
+	newLoadedValue, err := store.Load(ticketCookie)
+	if err != nil {
+		t.Errorf("RedisCookieStore.Load() error = %v", err)
+		return
+	}
+
+	if newLoadedValue != secondValue {
+		t.Errorf("RedisCookieStore.Store() = %v, expected %v", newLoadedValue, secondValue)
+	}
+
+	// Test Clearing an actual value
+	wasDeleted, err := store.Clear(ticketCookie)
+	if err != nil {
+		t.Errorf("RedisCookieStore.Clear() error = %v", err)
+		return
+	}
+	assert.Equal(t, true, wasDeleted)
+
+	// Test clearing with no value
+	wasDeleted, err = store.Clear(ticketCookie)
+	if err != nil {
+		t.Errorf("RedisCookieStore.Clear() error = %v", err)
+		return
+	}
+	assert.Equal(t, false, wasDeleted)
+}
+
+func Test_parseCookieTicket(t *testing.T) {
+	type args struct {
+		expectedPrefix string
+		ticket         string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		handle  string
+		iv      []byte
+		wantErr bool
+	}{
+		{
+			"Bad Prefix (not matching), Good ID, Good IV",
+			args{"oauth2_proxy",
+				"_oauth2_proxy-eb1bc8906a3111e98d4fa45e60f3cffd.MTIzNDU2Nzg5MDEyMzQ1Ng",
+			},
+			"",
+			nil,
+			true,
+		},
+		{
+			"Good Prefix, Bad ID (not hex), Good IV",
+			args{"oauth2_proxy",
+				"oauth2_proxy-foobar1234.MTIzNDU2Nzg5MDEyMzQ1Ng",
+			},
+			"",
+			nil,
+			true,
+		},
+		{
+			"Good Prefix, Good ID, Bad IV (not URL safe)",
+			args{"oauth2_proxy",
+				"oauth2_proxy-eb1bc8906a3111e98d4fa45e60f3cffd.+MTIzNDU2Nzg5MDEyMzQ1Ng",
+			},
+			"",
+			nil,
+			true,
+		},
+		{
+			"Good Prefix, Good ID, Good IV",
+			args{"oauth2_proxy",
+				"oauth2_proxy-eb1bc8906a3111e98d4fa45e60f3cffd.MTIzNDU2Nzg5MDEyMzQ1Ng",
+			},
+			"oauth2_proxy-eb1bc8906a3111e98d4fa45e60f3cffd",
+			[]byte("1234567890123456"),
+			false,
+		},
+		{
+			"Good Prefix with dash, Good ID, Good IV",
+			args{"oauth2-proxy",
+				"oauth2-proxy-eb1bc8906a3111e98d4fa45e60f3cffd.MTIzNDU2Nzg5MDEyMzQ1Ng",
+			},
+			"oauth2-proxy-eb1bc8906a3111e98d4fa45e60f3cffd",
+			[]byte("1234567890123456"),
+			false,
+		},
+		{
+			"Good Prefix with period, Good ID, Good IV",
+			args{"oauth2.proxy",
+				"oauth2.proxy-eb1bc8906a3111e98d4fa45e60f3cffd.MTIzNDU2Nzg5MDEyMzQ1Ng",
+			},
+			"oauth2.proxy-eb1bc8906a3111e98d4fa45e60f3cffd",
+			[]byte("1234567890123456"),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cookieHandle, iv, err := parseCookieTicket(tt.args.expectedPrefix, tt.args.ticket)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseCookieTicket() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if cookieHandle != tt.handle {
+				t.Errorf("parseCookieTicket() cookieHandle = %v, handle %v", cookieHandle, tt.handle)
+			}
+
+			if !reflect.DeepEqual(iv, tt.iv) {
+				t.Errorf("parseCookieTicket() iv = %v, iv %v", iv, tt.iv)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 	flagSet.Bool("skip-auth-preflight", false, "will skip authentication for OPTIONS requests")
 	flagSet.Bool("ssl-insecure-skip-verify", false, "skip validation of certificates presented when using HTTPS")
 	flagSet.Duration("flush-interval", time.Duration(1)*time.Second, "period between response flushing when streaming responses")
+	flagSet.String("redis-connection-url", "", "connection url for redis (activates server-side cookies with redis backend)")
 
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -491,8 +491,8 @@ func (p *OAuthProxy) LoadCookiedSession(req *http.Request) (*providers.SessionSt
 		// always http.ErrNoCookie
 		return nil, age, fmt.Errorf("Cookie %q not present", p.CookieName)
 	}
-	val, timestamp, ok := cookie.Validate(c, p.CookieSeed, p.CookieExpire)
-	if !ok {
+	val, timestamp, err := cookie.Validate(c, p.CookieSeed, p.CookieExpire)
+	if err != nil {
 		return nil, age, errors.New("Cookie Signature not valid")
 	}
 

--- a/options.go
+++ b/options.go
@@ -16,6 +16,7 @@ import (
 
 	oidc "github.com/coreos/go-oidc"
 	"github.com/dgrijalva/jwt-go"
+	"github.com/go-redis/redis"
 	"github.com/mbland/hmacauth"
 	"github.com/pusher/oauth2_proxy/logger"
 	"github.com/pusher/oauth2_proxy/providers"
@@ -44,6 +45,7 @@ type Options struct {
 	GoogleGroups             []string `flag:"google-group" cfg:"google_group" env:"OAUTH2_PROXY_GOOGLE_GROUPS"`
 	GoogleAdminEmail         string   `flag:"google-admin-email" cfg:"google_admin_email" env:"OAUTH2_PROXY_GOOGLE_ADMIN_EMAIL"`
 	GoogleServiceAccountJSON string   `flag:"google-service-account-json" cfg:"google_service_account_json" env:"OAUTH2_PROXY_GOOGLE_SERVICE_ACCOUNT_JSON"`
+	RedisConnectionURL       string   `flag:"redis-connection-url" cfg:"redis_connection_url"`
 	HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file" env:"OAUTH2_PROXY_HTPASSWD_FILE"`
 	DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form" env:"OAUTH2_PROXY_DISPLAY_HTPASSWD_FORM"`
 	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir" env:"OAUTH2_PROXY_CUSTOM_TEMPLATES_DIR"`
@@ -283,6 +285,13 @@ func (o *Options) Validate() error {
 					"pass_access_token == true or "+
 					"cookie_refresh != 0, but is %d bytes.%s",
 				len(secretBytes(o.CookieSecret)), suffix))
+		}
+	}
+
+	if o.RedisConnectionURL != "" {
+		_, err := redis.ParseURL(o.RedisConnectionURL)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf("unable to parse redis url: %s", err))
 		}
 	}
 


### PR DESCRIPTION
This is an implementation of #138 - A server-side cookies store.

## Description
This is an implementation of a Server Cookies Store. Instead of sending the user a cookie whose value is the encoded, encrypted session containing tokens, oauth2_proxy would send the user a ticket for that same cookie. 

The ticket would include information about how to retrieve the cookie, a handle. In addition to that, to preserve the current security aspect of oauth2_proxy, that ticket would also include information necessary to decrypt the cookie value.

When issuing a cookie, the handle would effectively be a random number to prevent collisions, we take a SHA-1 of the initial session to generate this, though generating a random number or UUID would work fine as well. The information necessary to decrypt the cookie is the random 16-byte initialization vector used to encrypt the cookie in the Redis store.

When refreshing a session, the handle from the current ticket is used to store that information

This also includes a change to the `Validate` interface which can bubble up an error if cookie validation fails. This was useful for debugging issues when implementing a store.

## Motivation and Context
Implementing  #138.

## How Has This Been Tested?

Unit tests for the store interface, including an instance of miniredis. These changes are cherry picked from another branch that has been tested in a kuberenetes cluster with the auth-url setting, with changes from #65 as well.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
