### PR TITLE
Check google group membership based on email address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 - [#111](https://github.com/pusher/oauth2_proxy/pull/111) Add option for telling where to find a login.gov JWT key file (@timothy-spencer)
 
+- [#141](https://github.com/pusher/oauth2_proxy/pull/141) Check google group membership based on email address (@bchess)
+  - Google Group membership is additionally checked via email address, allowing users outside a GSuite domain to be authorized.
+
 # v3.2.0
 
 ## Release highlights

--- a/providers/google.go
+++ b/providers/google.go
@@ -186,7 +186,7 @@ func getAdminService(adminEmail string, credentialsReader io.Reader) *admin.Serv
 func userInGroup(service *admin.Service, groups []string, email string) bool {
 	user, err := fetchUser(service, email)
 	if err != nil {
-		logger.Printf("error fetching user: %v", err)
+		logger.Printf("Warning: unable to fetch user: %v", err)
 		user = nil
 	}
 

--- a/providers/google.go
+++ b/providers/google.go
@@ -187,10 +187,8 @@ func userInGroup(service *admin.Service, groups []string, email string) bool {
 	user, err := fetchUser(service, email)
 	if err != nil {
 		logger.Printf("error fetching user: %v", err)
-		return false
+		user = nil
 	}
-	id := user.Id
-	custID := user.CustomerId
 
 	for _, group := range groups {
 		members, err := fetchGroupMembers(service, group)
@@ -204,13 +202,19 @@ func userInGroup(service *admin.Service, groups []string, email string) bool {
 		}
 
 		for _, member := range members {
+			if member.Email == email {
+				return true
+			}
+			if user == nil {
+				continue
+			}
 			switch member.Type {
 			case "CUSTOMER":
-				if member.Id == custID {
+				if member.Id == user.CustomerId {
 					return true
 				}
 			case "USER":
-				if member.Id == id {
+				if member.Id == user.Id {
 					return true
 				}
 			}


### PR DESCRIPTION
## Description

This matches against actual email address field of the google group members, in addition to checking id and customerId.

I'm not sure we need both ID and email checks, but I kept the existing behavior just in case. 

## Motivation and Context

See Issue #95 for some motivation and context.

## How Has This Been Tested?

Tested interactively with an email address outside the GSuite domain. Tested with external email addresses that both have and have not already have Google Accounts. Wrote a unit test also.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
