### PR TITLE
fix Docker user on arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes since v3.2.0
 
+- [#142](https://github.com/pusher/oauth2_proxy/pull/142) ARM Docker USER fix (@kskewes)
 - [#52](https://github.com/pusher/oauth2_proxy/pull/52) Logging Improvements (@MisterWil)
   - Implement flags to configure file logging
     - `-logging-filename` Defines the filename to log to

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/jwt_signing_key.pem /etc/ssl/private/jwt_signing_key.pem
 
-RUN addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy
-USER oauth2proxy
+USER 2000:2000
 
 ENTRYPOINT ["/bin/oauth2_proxy"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.11-stretch AS builder
+FROM golang:1.12-stretch AS builder
 
 # Download tools
 RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
@@ -25,7 +25,6 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/jwt_signing_key.pem /etc/ssl/private/jwt_signing_key.pem
 
-RUN addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy
-USER oauth2proxy
+USER 2000:2000
 
 ENTRYPOINT ["/bin/oauth2_proxy"]

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -1,4 +1,4 @@
-FROM golang:1.11-stretch AS builder
+FROM golang:1.12-stretch AS builder
 
 # Download tools
 RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
@@ -25,7 +25,6 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/oauth2_proxy /bin/oauth2_proxy
 COPY --from=builder /go/src/github.com/pusher/oauth2_proxy/jwt_signing_key.pem /etc/ssl/private/jwt_signing_key.pem
 
-RUN addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy
-USER oauth2proxy
+USER 2000:2000
 
 ENTRYPOINT ["/bin/oauth2_proxy"]


### PR DESCRIPTION
## Description

Use simple USER directive.
Using `addgroup` in final `arm` image when building on amd64 doesn't work.
I must have made a mistake during cross build verification in #85 .

Alternative is to use qemu-static but it's not worth it for this.

## Motivation and Context

Currently `make docker-all` fails on arm image build: 
```
 ---> c3d3a165fb2f                                                                                                              
Step 12/14 : RUN addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy                                                                  
 ---> Running in 9fa5a83bce05                                                                                                                                           
standard_init_linux.go:207: exec user process caused "no such file or directory"                                                                                        
The command '/bin/sh -c addgroup -S -g 2000 oauth2proxy && adduser -S -u 2000 oauth2proxy -G oauth2proxy' returned a non-zero code: 1                                   
Makefile:54: recipe for target 'docker-all' failed                                                                                                                      
make: *** [docker-all] Error 1     
```

## How Has This Been Tested?

`make docker-all` succeeds.

Verifying `--version` on arm64.
```
karl@k8s-w-01:~$ docker run --rm -it oauth2_proxy:latest-arm64 --version                                
oauth2_proxy v3.2.0-22-g93b7d31-dirty (built with go1.11.9)  
```

Verifying user on arm64.
```
karl@k8s-w-01:~$ docker run --rm -it --entrypoint ash oauth2_proxy:latest-arm64      
/ $ ls                                           
bin    dev    etc    home   lib    media  mnt    proc   root   run    sbin   srv    sys    tmp    usr    var
/ $ whoami                                                                                                
whoami: unknown uid 2000
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
