### PR TITLE
Do not infer username from email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Vx.x.x (Pre-release)
 
+## Breaking Changes
+
+- [#146](https://github.com/pusher/oauth2_proxy/pull/146) Use full email address as `User` if the auth response did not contain a `User` field (@gargath)
+  - This change modifies the contents of the `X-Forwarded-User` header supplied by the proxy for users where the auth response from the IdP did not contain
+    a username.
+    In that case, this header used to only contain the local part of the user's email address (e.g. `john.doe` for `john.doe@example.com`) but now contains
+    the user's full email address instead.
+
 ## Changes since v3.2.0
 
-- [#146](https://github.com/pusher/oauth2_proxy/pull/146) Use full email address as `User` if the auth response did not contains a `User` field (@gargath)
+- [#146](https://github.com/pusher/oauth2_proxy/pull/146) Use full email address as `User` if the auth response did not contain a `User` field (@gargath)
 - [#144](https://github.com/pusher/oauth2_proxy/pull/144) Use GO 1.12 for ARM builds (@kskewes)
 - [#142](https://github.com/pusher/oauth2_proxy/pull/142) ARM Docker USER fix (@kskewes)
 - [#52](https://github.com/pusher/oauth2_proxy/pull/52) Logging Improvements (@MisterWil)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changes since v3.2.0
 
+- [#146](https://github.com/pusher/oauth2_proxy/pull/146) Use full email address as `User` if the auth response did not contains a `User` field (@gargath)
 - [#144](https://github.com/pusher/oauth2_proxy/pull/144) Use GO 1.12 for ARM builds (@kskewes)
 - [#142](https://github.com/pusher/oauth2_proxy/pull/142) ARM Docker USER fix (@kskewes)
 - [#52](https://github.com/pusher/oauth2_proxy/pull/52) Logging Improvements (@MisterWil)

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ docker-push-all: docker-push
 
 .PHONY: test
 test: dep lint
-	$(GO) test -v -race $(go list ./... | grep -v /vendor/)
+	$(GO) test -v -race ./...
 
 .PHONY: release
 release: lint test

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -291,8 +291,7 @@ func TestBasicAuthPassword(t *testing.T) {
 	opts.Validate()
 
 	providerURL, _ := url.Parse(providerServer.URL)
-	const emailAddress = "michael.bland@gsa.gov"
-	const username = "michael.bland"
+	const emailAddress = "john.doe@example.com"
 
 	opts.provider = NewTestProvider(providerURL, emailAddress)
 	proxy := NewOAuthProxy(opts, func(email string) bool {
@@ -335,7 +334,7 @@ func TestBasicAuthPassword(t *testing.T) {
 	rw = httptest.NewRecorder()
 	proxy.ServeHTTP(rw, req)
 
-	expectedHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+opts.BasicAuthPassword))
+	expectedHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(emailAddress+":"+opts.BasicAuthPassword))
 	assert.Equal(t, expectedHeader, rw.Body.String())
 	providerServer.Close()
 }
@@ -654,13 +653,13 @@ func (p *ProcessCookieTest) LoadCookiedSession() (*providers.SessionState, time.
 func TestLoadCookiedSession(t *testing.T) {
 	pcTest := NewProcessCookieTestWithDefaults()
 
-	startSession := &providers.SessionState{Email: "michael.bland@gsa.gov", AccessToken: "my_access_token"}
+	startSession := &providers.SessionState{Email: "john.doe@example.com", AccessToken: "my_access_token"}
 	pcTest.SaveSession(startSession, time.Now())
 
 	session, _, err := pcTest.LoadCookiedSession()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, startSession.Email, session.Email)
-	assert.Equal(t, "michael.bland", session.User)
+	assert.Equal(t, "john.doe@example.com", session.User)
 	assert.Equal(t, startSession.AccessToken, session.AccessToken)
 }
 

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -334,6 +334,8 @@ func TestBasicAuthPassword(t *testing.T) {
 	rw = httptest.NewRecorder()
 	proxy.ServeHTTP(rw, req)
 
+	// The username in the basic auth credentials is expected to be equal to the email address from the
+	// auth response, so we use the same variable here.
 	expectedHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(emailAddress+":"+opts.BasicAuthPassword))
 	assert.Equal(t, expectedHeader, rw.Body.String())
 	providerServer.Close()

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -128,6 +128,7 @@ func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Tok
 		RefreshToken: token.RefreshToken,
 		ExpiresOn:    token.Expiry,
 		Email:        claims.Email,
+		User:         claims.Subject,
 	}, nil
 }
 

--- a/providers/session_state.go
+++ b/providers/session_state.go
@@ -218,7 +218,7 @@ func DecodeSessionState(v string, c *cookie.Cipher) (*SessionState, error) {
 		}
 	}
 	if ss.User == "" {
-		ss.User = strings.Split(ss.Email, "@")[0]
+		ss.User = ss.Email
 	}
 	return ss, nil
 }

--- a/providers/session_state_test.go
+++ b/providers/session_state_test.go
@@ -30,7 +30,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	ss, err := DecodeSessionState(encoded, c)
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "user", ss.User)
+	assert.Equal(t, "user@domain.com", ss.User)
 	assert.Equal(t, s.Email, ss.Email)
 	assert.Equal(t, s.AccessToken, ss.AccessToken)
 	assert.Equal(t, s.IDToken, ss.IDToken)
@@ -41,7 +41,7 @@ func TestSessionStateSerialization(t *testing.T) {
 	ss, err = DecodeSessionState(encoded, c2)
 	t.Logf("%#v", ss)
 	assert.Equal(t, nil, err)
-	assert.NotEqual(t, "user", ss.User)
+	assert.NotEqual(t, "user@domain.com", ss.User)
 	assert.NotEqual(t, s.Email, ss.Email)
 	assert.Equal(t, s.ExpiresOn.Unix(), ss.ExpiresOn.Unix())
 	assert.NotEqual(t, s.AccessToken, ss.AccessToken)
@@ -97,7 +97,7 @@ func TestSessionStateSerializationNoCipher(t *testing.T) {
 	// only email should have been serialized
 	ss, err := DecodeSessionState(encoded, nil)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "user", ss.User)
+	assert.Equal(t, "user@domain.com", ss.User)
 	assert.Equal(t, s.Email, ss.Email)
 	assert.Equal(t, "", ss.AccessToken)
 	assert.Equal(t, "", ss.RefreshToken)
@@ -203,7 +203,7 @@ func TestDecodeSessionState(t *testing.T) {
 		{
 			SessionState: SessionState{
 				Email: "user@domain.com",
-				User:  "user",
+				User:  "user@domain.com",
 			},
 			Encoded: `{"Email":"user@domain.com"}`,
 		},


### PR DESCRIPTION
## Description

If the auth provider does not return a `username` as part of the auth response, the proxy would infer a username by using the local part of the user's email (e.g. `john.doe` for `john.doe@example.com`).

This change uses the entire email address instead to remove potential ambiguity between different users with the same email local part.

*Note:* This is a breaking change.

## Motivation and Context

With the previous behaviour, the username stored in the session for users `john.doe@example.com` and `john.doe@server.invalid` would be identical even though both users are likely to be different individuals.


## How Has This Been Tested?

Test suites have been changed to reflect the new expected behaviour.


## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
