### PR TITLE
fixing code redemption error string logging

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -751,7 +751,7 @@ func (p *OAuthProxy) OAuthCallback(rw http.ResponseWriter, req *http.Request) {
 
 	session, err := p.redeemCode(req.Host, req.Form.Get("code"))
 	if err != nil {
-		logger.Printf("Error redeeming code during OAuth2 callback: %s ", errorString)
+		logger.Printf("Error redeeming code during OAuth2 callback: %s ", err.Error())
 		p.ErrorPage(rw, 500, "Internal Error", "Internal Error")
 		return
 	}


### PR DESCRIPTION
## Description

Bugfix:  When logging got updated, it appears as if the code redemption error string got changed to the wrong thing.

## Motivation and Context

I am trying to debug a problem with an app that is not able to redeem the code, but there's no error string, so I would like to get that working so that I can understand what the problem really is.

## How Has This Been Tested?

I ran `go test ./...` and deployed a version in my test environment.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
