### PR TITLE
Set Jekyll URL to https://pusher.github.io/oauth2_proxy

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,8 +16,8 @@
 title: OAuth2_Proxy
 description: >- # this means to ignore newlines until "baseurl:"
   OAuth2_Proxy documentation site
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/oauth2_proxy" # the subpath of your site, e.g. /blog
+url: "https://pusher.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Jekyll URL settings aren't correct so the Jekyll site doesn't currently render. This _should_ fix that I think 🤔 

Perhaps we could use a pusher domain to set up a vanity URL? 

## How Has This Been Tested?

Guesswork and a little developer tools on chrome

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
