### PR TITLE
Redis session store 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,14 @@
 
 - [#155](https://github.com/pusher/outh2_proxy/pull/155) Add RedisSessionStore implementation (@brianv0, @JoelSpeed)
   - Implement flags to configure the redis session store
-    -  `-redis-connection-url`
-  - Introduces the concept of a session ticket. Tickets are composed of the cookie name, a session ID, and a secret. 
-  - Sessions are stored encrypted with a per-session secret 
-  - Added Some tests for a Server based session store
+    - `-session-store-type=redis` Sets the store type to redis
+    - `-redis-connection-url` Sets the Redis connection URL
+    - `-redis-use-sentinel=true` Enables Redis Sentinel support
+    - `-redis-sentinel-master-name` Sets the Sentinel master name, if sentinel is enabled
+    - `-redis-sentinel-connection-urls` Defines the Redis Sentinel Connection URLs, if sentinel is enabled
+  - Introduces the concept of a session ticket. Tickets are composed of the cookie name, a session ID, and a secret.
+  - Redis Sessions are stored encrypted with a per-session secret 
+  - Added tests for server based session stores
 - [#168](https://github.com/pusher/outh2_proxy/pull/168) Drop Go 1.11 support in Travis (@JoelSpeed)
 - [#169](https://github.com/pusher/outh2_proxy/pull/169) Update Alpine to 3.9 (@kskewes)
 - [#148](https://github.com/pusher/outh2_proxy/pull/148) Implement SessionStore interface within proxy (@JoelSpeed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ## Changes since v3.2.0
 
+- [#155](https://github.com/pusher/outh2_proxy/pull/155) Add RedisSessionStore implementation (@brianv0, @JoelSpeed)
+  - Implement flags to configure the redis session store
+    -  `-redis-connection-url`
+  - Introduces the concept of a session ticket. Tickets are composed of the cookie name, a session ID, and a secret. 
+  - Sessions are stored encrypted with a per-session secret 
+  - Added Some tests for a Server based session store
 - [#168](https://github.com/pusher/outh2_proxy/pull/168) Drop Go 1.11 support in Travis (@JoelSpeed)
 - [#169](https://github.com/pusher/outh2_proxy/pull/169) Update Alpine to 3.9 (@kskewes)
 - [#148](https://github.com/pusher/outh2_proxy/pull/148) Implement SessionStore interface within proxy (@JoelSpeed)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,25 @@
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:3cce78d5d0090e3f1162945fba60ba74e72e8422e8e41bb9c701afb67237bb65"
+  name = "github.com/alicebob/gopher-json"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5a6b3ba71ee69b77cf64febf8b5a7526ca5eaef0"
+
+[[projects]]
+  digest = "1:18a07506ddaa87b1612bfd69eef03f510faf122398df3da774d46dcfe751a060"
+  name = "github.com/alicebob/miniredis"
+  packages = [
+    ".",
+    "server",
+  ]
+  pruneopts = ""
+  revision = "3d7aa1333af56ab862d446678d93aaa6803e0938"
+  version = "v2.7.0"
+
+[[projects]]
   digest = "1:512883404c2a99156e410e9880e3bb35ecccc0c07c1159eb204b5f3ef3c431b3"
   name = "github.com/bitly/go-simplejson"
   packages = ["."]
@@ -50,12 +69,39 @@
   version = "v3.2.0"
 
 [[projects]]
+  digest = "1:8c7410dae63c74bd92db09bf33af7e0698b635ab6a397fd8e9e10dfcce3138ac"
+  name = "github.com/go-redis/redis"
+  packages = [
+    ".",
+    "internal",
+    "internal/consistenthash",
+    "internal/hashtag",
+    "internal/pool",
+    "internal/proto",
+    "internal/util",
+  ]
+  pruneopts = ""
+  revision = "d22fde8721cc915a55aeb6b00944a76a92bfeb6e"
+  version = "v6.15.2"
+
+[[projects]]
   branch = "master"
   digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   pruneopts = ""
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+
+[[projects]]
+  digest = "1:dcf8316121302735c0ac84e05f4686e3b34e284444435e9a206da48d8be18cb1"
+  name = "github.com/gomodule/redigo"
+  packages = [
+    "internal",
+    "redis",
+  ]
+  pruneopts = ""
+  revision = "9c11da706d9b7902c6da69c592f75637793fe121"
+  version = "v2.0.0"
 
 [[projects]]
   digest = "1:b3c5b95e56c06f5aa72cb2500e6ee5f44fcd122872d4fec2023a488e561218bc"
@@ -172,6 +218,19 @@
   packages = ["."]
   pruneopts = ""
   revision = "1d66fa95c997864ba4d8479f56609620fe542928"
+
+[[projects]]
+  branch = "master"
+  digest = "1:378d29a839ff770e9d9150580b4c01ff0a513a296b0487558a7af7c18adab98e"
+  name = "github.com/yuin/gopher-lua"
+  packages = [
+    ".",
+    "ast",
+    "parse",
+    "pm",
+  ]
+  pruneopts = ""
+  revision = "8bfc7677f583b35a5663a9dd934c08f3b5774bbb"
 
 [[projects]]
   branch = "master"
@@ -341,9 +400,11 @@
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
+    "github.com/alicebob/miniredis",
     "github.com/bitly/go-simplejson",
     "github.com/coreos/go-oidc",
     "github.com/dgrijalva/jwt-go",
+    "github.com/go-redis/redis",
     "github.com/mbland/hmacauth",
     "github.com/mreiferson/go-options",
     "github.com/onsi/ginkgo",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,6 +50,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/go-redis/redis"
+  version = "v6.15.2"
 
 [[constraint]]
   name = "github.com/alicebob/miniredis"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,3 +46,11 @@
 [[constraint]]
   name = "gopkg.in/natefinch/lumberjack.v2"
   version = "2.1.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/go-redis/redis"
+
+[[constraint]]
+  name = "github.com/alicebob/miniredis"
+  version = "2.7.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,6 @@
   version = "2.1.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/go-redis/redis"
   version = "v6.15.2"
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -75,6 +75,7 @@ Usage of oauth2_proxy:
   -pubjwk-url string: JWK pubkey access endpoint: required by login.gov
   -redeem-url string: Token redemption endpoint
   -redirect-url string: the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
+  -redis-connection-url string: URL of redis server for redis session storage type (eg: redis://HOST[:PORT])
   -request-logging: Log requests to stdout (default true)
   -request-logging-format: Template for request log lines (see "Logging Configuration" paragraph below)
   -resource string: The resource that is protected (Azure AD only)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -75,7 +75,10 @@ Usage of oauth2_proxy:
   -pubjwk-url string: JWK pubkey access endpoint: required by login.gov
   -redeem-url string: Token redemption endpoint
   -redirect-url string: the OAuth Redirect URL. ie: "https://internalapp.yourcompany.com/oauth2/callback"
-  -redis-connection-url string: URL of redis server for redis session storage type (eg: redis://HOST[:PORT])
+  -redis-connection-url string: URL of redis server for redis session storage (eg: redis://HOST[:PORT])
+  -redis-sentinel-master-name string: Redis sentinel master name. Used in conjuction with --redis-use-sentinel
+  -redis-sentinel-connection-urls: List of Redis sentinel conneciton URLs (eg redis://HOST[:PORT]). Used in conjuction with --redis-use-sentinel
+  -redis-use-sentinel: Connect to redis via sentinels. Must set --redis-sentinel-master-name and --redis-sentinel-connection-urls to use this feature (default: false)
   -request-logging: Log requests to stdout (default true)
   -request-logging-format: Template for request log lines (see "Logging Configuration" paragraph below)
   -resource string: The resource that is protected (Azure AD only)

--- a/docs/configuration/sessions.md
+++ b/docs/configuration/sessions.md
@@ -16,6 +16,7 @@ data in one of the available session storage backends.
 
 At present the available backends are (as passed to `--session-store-type`):
 - [cookie](cookie-storage) (default)
+- [redis](redis-storage)
 
 ### Cookie Storage
 
@@ -32,3 +33,26 @@ The following should be known when using this implementation:
 - Since multiple requests can be made concurrently to the OAuth2 Proxy, this session implementation
 cannot lock sessions and while updating and refreshing sessions, there can be conflicts which force
 users to re-authenticate
+
+
+### Redis Storage
+
+The Redis Storage backend stores sessions, encrypted, in redis. Instead sending all the information
+back the the client for storage, as in the [Cookie storage](cookie-storage), a ticket is sent back
+to the user as the cookie value instead.
+
+A ticket is composed as the following:
+
+`{CookieName}-{ticketID}.{secret}`
+
+Where:
+
+- The `CookieName` is the OAuth2 cookie name (_oauth2_proxy by default)
+- The `ticketID` is a 128 bit random number, hex-encoded
+- The `secret` is a 128 bit random number, base64url encoded (no padding). The secret is unique for every session.
+- The pair of `{CookieName}-{ticketID}` comprises a ticket handle, and thus, the redis key
+to which the session is stored. The encoded session is encrypted with the secret and stored
+in redis via the `SETEX` command.
+
+Encrypting every session uniquely protects the refresh/access/id tokens stored in the session from
+disclosure.

--- a/docs/configuration/sessions.md
+++ b/docs/configuration/sessions.md
@@ -56,3 +56,12 @@ in redis via the `SETEX` command.
 
 Encrypting every session uniquely protects the refresh/access/id tokens stored in the session from
 disclosure.
+
+#### Usage
+
+When using the redis store, specify `--session-store-type=redis` as well as the Redis connection URL, via
+`--redis-connection-url=redis://host[:port][/db-number]`.
+
+You may also configure the store for Redis Sentinel. In this case, you will want to use the 
+`--redis-use-sentinel=true` flag, as well as configure the flags `--redis-sentinel-master-name` 
+and `--redis-sentinel-connection-urls` appropriately.

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
 	flagSet.String("session-store-type", "cookie", "the session storage provider to use")
+	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage (eg: redis://HOST[:PORT])")
 
 	flagSet.String("logging-filename", "", "File to log requests to, empty for stdout")
 	flagSet.Int("logging-max-size", 100, "Maximum size in megabytes of the log file before rotation")

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	upstreams := StringArray{}
 	skipAuthRegex := StringArray{}
 	googleGroups := StringArray{}
+	redisSentinelConnectionURLs := StringArray{}
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -76,7 +77,10 @@ func main() {
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
 	flagSet.String("session-store-type", "cookie", "the session storage provider to use")
-	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage type (eg: redis://HOST[:PORT])")
+	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage (eg: redis://HOST[:PORT])")
+	flagSet.Bool("redis-use-sentinel", false, "Connect to redis via sentinels. Must set --redis-sentinel-master-name and --redis-sentinel-conneciton-urls to use this feature")
+	flagSet.String("redis-sentinel-master-name", "", "Redis sentinel master name. Used in conjuction with --redis-use-sentinel")
+	flagSet.Var(&redisSentinelConnectionURLs, "redis-sentinel-connection-urls", "List of Redis sentinel conneciton URLs (eg redis://HOST[:PORT]). Used in conjuction with --redis-use-sentinel")
 
 	flagSet.String("logging-filename", "", "File to log requests to, empty for stdout")
 	flagSet.Int("logging-max-size", 100, "Maximum size in megabytes of the log file before rotation")

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 
 	flagSet.String("session-store-type", "cookie", "the session storage provider to use")
-	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage (eg: redis://HOST[:PORT])")
+	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage type (eg: redis://HOST[:PORT])")
 
 	flagSet.String("logging-filename", "", "File to log requests to, empty for stdout")
 	flagSet.Int("logging-max-size", 100, "Maximum size in megabytes of the log file before rotation")

--- a/main.go
+++ b/main.go
@@ -78,9 +78,9 @@ func main() {
 
 	flagSet.String("session-store-type", "cookie", "the session storage provider to use")
 	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage (eg: redis://HOST[:PORT])")
-	flagSet.Bool("redis-use-sentinel", false, "Connect to redis via sentinels. Must set --redis-sentinel-master-name and --redis-sentinel-conneciton-urls to use this feature")
+	flagSet.Bool("redis-use-sentinel", false, "Connect to redis via sentinels. Must set --redis-sentinel-master-name and --redis-sentinel-connection-urls to use this feature")
 	flagSet.String("redis-sentinel-master-name", "", "Redis sentinel master name. Used in conjuction with --redis-use-sentinel")
-	flagSet.Var(&redisSentinelConnectionURLs, "redis-sentinel-connection-urls", "List of Redis sentinel conneciton URLs (eg redis://HOST[:PORT]). Used in conjuction with --redis-use-sentinel")
+	flagSet.Var(&redisSentinelConnectionURLs, "redis-sentinel-connection-urls", "List of Redis sentinel connection URLs (eg redis://HOST[:PORT]). Used in conjuction with --redis-use-sentinel")
 
 	flagSet.String("logging-filename", "", "File to log requests to, empty for stdout")
 	flagSet.Int("logging-max-size", 100, "Maximum size in megabytes of the log file before rotation")

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -9,6 +9,7 @@ type SessionOptions struct {
 	Type   string `flag:"session-store-type" cfg:"session_store_type" env:"OAUTH2_PROXY_SESSION_STORE_TYPE"`
 	Cipher *cookie.Cipher
 	CookieStoreOptions
+	RedisStoreOptions
 }
 
 // CookieSessionStoreType is used to indicate the CookieSessionStore should be
@@ -17,3 +18,12 @@ var CookieSessionStoreType = "cookie"
 
 // CookieStoreOptions contains configuration options for the CookieSessionStore.
 type CookieStoreOptions struct{}
+
+// RedisSessionStoreType is used to indicate the CookieSessionStore should be
+// used for storing sessions.
+var RedisSessionStoreType = "redis"
+
+// RedisStoreOptions contains configuration options for the CookieSessionStore.
+type RedisStoreOptions struct {
+	RedisConnectionURL string `flag:"redis-connection-url" cfg:"redis_connection_url" env:"OAUTH2_PROXY_REDIS_CONNECTION_URL"`
+}

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -19,11 +19,11 @@ var CookieSessionStoreType = "cookie"
 // CookieStoreOptions contains configuration options for the CookieSessionStore.
 type CookieStoreOptions struct{}
 
-// RedisSessionStoreType is used to indicate the CookieSessionStore should be
+// RedisSessionStoreType is used to indicate the RedisSessionStore should be
 // used for storing sessions.
 var RedisSessionStoreType = "redis"
 
-// RedisStoreOptions contains configuration options for the CookieSessionStore.
+// RedisStoreOptions contains configuration options for the RedisSessionStore.
 type RedisStoreOptions struct {
 	RedisConnectionURL string `flag:"redis-connection-url" cfg:"redis_connection_url" env:"OAUTH2_PROXY_REDIS_CONNECTION_URL"`
 }

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -25,5 +25,8 @@ var RedisSessionStoreType = "redis"
 
 // RedisStoreOptions contains configuration options for the RedisSessionStore.
 type RedisStoreOptions struct {
-	RedisConnectionURL string `flag:"redis-connection-url" cfg:"redis_connection_url" env:"OAUTH2_PROXY_REDIS_CONNECTION_URL"`
+	RedisConnectionURL     string   `flag:"redis-connection-url" cfg:"redis_connection_url" env:"OAUTH2_PROXY_REDIS_CONNECTION_URL"`
+	UseSentinel            bool     `flag:"redis-use-sentinel" cfg:"redis_use_sentinel" env:"OAUTH2_PROXY_REDIS_USE_SENTINEL"`
+	SentinelMasterName     string   `flag:"redis-sentinel-master-name" cfg:"redis_sentinel_master_name" env:"OAUTH2_PROXY_REDIS_SENTINEL_MASTER_NAME"`
+	SentinelConnectionURLs []string `flag:"redis-sentinel-connection-urls" cfg:"redis_sentinel_connection_urls" env:"OAUTH2_PROXY_REDIS_SENTINEL_CONNECTION_URLS"`
 }

--- a/pkg/apis/sessions/session_state.go
+++ b/pkg/apis/sessions/session_state.go
@@ -203,14 +203,14 @@ func DecodeSessionState(v string, c *cookie.Cipher) (*SessionState, error) {
 			User:  ss.User,
 		}
 	} else {
-		// Backward compatibility with using unecrypted Email
+		// Backward compatibility with using unencrypted Email
 		if ss.Email != "" {
 			decryptedEmail, errEmail := c.Decrypt(ss.Email)
 			if errEmail == nil {
 				ss.Email = decryptedEmail
 			}
 		}
-		// Backward compatibility with using unecrypted User
+		// Backward compatibility with using unencrypted User
 		if ss.User != "" {
 			decryptedUser, errUser := c.Decrypt(ss.User)
 			if errUser == nil {

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -197,7 +197,7 @@ func (store *SessionStore) storeValue(value string, expiresOn time.Time, request
 		return "", fmt.Errorf("error initiating cipher block %s", err)
 	}
 
-	// Use secret as the IV too, because each entry has it's own key
+	// Use secret as the Initialization Vector too, because each entry has it's own key
 	stream := cipher.NewCFBEncrypter(block, ticket.Secret)
 	stream.XORKeyStream(ciphertext, []byte(value))
 

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -250,7 +250,6 @@ func decodeTicket(cookieName string, ticketString string) (*TicketData, error) {
 	_, err := hex.DecodeString(ticketID)
 	if err != nil {
 		return nil, fmt.Errorf("server ticket failed sanity checks")
-		// s is not a valid
 	}
 
 	secret, err := base64.RawURLEncoding.DecodeString(secretBase64)

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -55,6 +55,10 @@ func NewRedisSessionStore(opts *options.SessionOptions, cookieOpts *options.Cook
 // Save takes a sessions.SessionState and stores the information from it
 // to redies, and adds a new ticket cookie on the HTTP response writer
 func (store *SessionStore) Save(rw http.ResponseWriter, req *http.Request, s *sessions.SessionState) error {
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = time.Now()
+	}
+
 	// Old sessions that we are refreshing would have a request cookie
 	// New sessions don't, so we ignore the error. storeValue will check requestCookie
 	requestCookie, _ := req.Cookie(store.CookieOptions.CookieName)
@@ -73,7 +77,7 @@ func (store *SessionStore) Save(rw http.ResponseWriter, req *http.Request, s *se
 		ticketString,
 		store.CookieOptions,
 		store.CookieOptions.CookieExpire,
-		time.Now(),
+		s.CreatedAt,
 	)
 
 	http.SetCookie(rw, ticketCookie)

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -237,7 +237,12 @@ func (store *SessionStore) getTicket(requestCookie *http.Cookie) (*TicketData, e
 	}
 
 	// Valid cookie, decode the ticket
-	return decodeTicket(store.CookieOptions.CookieName, val)
+	ticket, err := decodeTicket(store.CookieOptions.CookieName, val)
+	if err != nil {
+		// If we can't decode the ticket we have to create a new one
+		return newTicket()
+	}
+	return ticket, nil
 }
 
 func newTicket() (*TicketData, error) {

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -82,7 +82,7 @@ func (store *SessionStore) Save(rw http.ResponseWriter, req *http.Request, s *se
 	if err != nil {
 		return err
 	}
-	ticketString, err := store.storeValue(value, s.ExpiresOn, requestCookie)
+	ticketString, err := store.storeValue(value, store.CookieOptions.CookieExpire, requestCookie)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (store *SessionStore) makeCookie(req *http.Request, value string, expires t
 	)
 }
 
-func (store *SessionStore) storeValue(value string, expiresOn time.Time, requestCookie *http.Cookie) (string, error) {
+func (store *SessionStore) storeValue(value string, expiration time.Duration, requestCookie *http.Cookie) (string, error) {
 	var ticket *TicketData
 	if requestCookie != nil {
 		var err error
@@ -225,7 +225,6 @@ func (store *SessionStore) storeValue(value string, expiresOn time.Time, request
 	stream.XORKeyStream(ciphertext, []byte(value))
 
 	handle := ticket.asHandle(store.CookieOptions.CookieName)
-	expiration := expiresOn.Sub(time.Now())
 	err = store.Client.Set(handle, ciphertext, expiration).Err()
 	if err != nil {
 		return "", err

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -195,7 +195,14 @@ func (store *SessionStore) storeValue(value string, expiresOn time.Time, request
 	var ticket *TicketData
 	if requestCookie != nil {
 		var err error
-		ticket, err = decodeTicket(store.CookieOptions.CookieName, requestCookie.Value)
+		val, _, ok := cookie.Validate(requestCookie, store.CookieOptions.CookieSecret, store.CookieOptions.CookieExpire)
+		if !ok {
+			ticket, err = newTicket()
+			if err != nil {
+				return "", fmt.Errorf("error creating new ticket: %s", err)
+			}
+		}
+		ticket, err = decodeTicket(store.CookieOptions.CookieName, val)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -94,15 +94,15 @@ func (store *SessionStore) Load(req *http.Request) (*sessions.SessionState, erro
 	if !ok {
 		return nil, fmt.Errorf("Cookie Signature not valid")
 	}
-	session, err := store.LoadSessionFromString(val)
+	session, err := store.loadSessionFromString(val)
 	if err != nil {
 		return nil, fmt.Errorf("error loading session: %s", err)
 	}
 	return session, nil
 }
 
-// LoadSessionFromString loads the session based on the ticket value
-func (store *SessionStore) LoadSessionFromString(value string) (*sessions.SessionState, error) {
+// loadSessionFromString loads the session based on the ticket value
+func (store *SessionStore) loadSessionFromString(value string) (*sessions.SessionState, error) {
 	ticket, err := decodeTicket(store.CookieOptions.CookieName, value)
 	if err != nil {
 		return nil, err

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -1,0 +1,271 @@
+package redis
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-redis/redis"
+	"github.com/pusher/oauth2_proxy/cookie"
+	"github.com/pusher/oauth2_proxy/pkg/apis/options"
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"github.com/pusher/oauth2_proxy/pkg/cookies"
+	"github.com/pusher/oauth2_proxy/pkg/sessions/utils"
+)
+
+// TicketData is a structure representing a used in server session storage
+type TicketData struct {
+	TicketID string
+	Secret   []byte
+}
+
+// SessionStore is an implementation of the sessions.SessionStore
+// interface that stores sessions in redis
+type SessionStore struct {
+	CookieCipher   *cookie.Cipher
+	CookieDomain   string
+	CookieExpire   time.Duration
+	CookieHTTPOnly bool
+	CookieName     string
+	CookiePath     string
+	CookieSecret   string
+	CookieSecure   bool
+	Client         *redis.Client
+}
+
+// NewRedisSessionStore initialises a new instance of the SessionStore from
+// the configuration given
+func NewRedisSessionStore(opts options.RedisStoreOptions, cookieOpts *options.CookieOptions) (sessions.SessionStore, error) {
+	opt, err := redis.ParseURL(opts.RedisConnectionURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse redis url: %s", err)
+	}
+
+	var cookieCipher *cookie.Cipher
+	if len(cookieOpts.CookieSecret) > 0 {
+		var err error
+		cookieCipher, err = cookie.NewCipher(utils.SecretBytes(cookieOpts.CookieSecret))
+		if err != nil {
+			return nil, fmt.Errorf("unable to create cookieCipher: %v", err)
+		}
+	}
+
+	client := redis.NewClient(opt)
+
+	rs := &SessionStore{
+		Client:         client,
+		CookieCipher:   cookieCipher,
+		CookieDomain:   cookieOpts.CookieDomain,
+		CookieExpire:   cookieOpts.CookieExpire,
+		CookieHTTPOnly: cookieOpts.CookieHTTPOnly,
+		CookieName:     cookieOpts.CookieName,
+		CookiePath:     cookieOpts.CookiePath,
+		CookieSecret:   cookieOpts.CookieSecret,
+		CookieSecure:   cookieOpts.CookieSecure,
+	}
+	return rs, nil
+
+}
+
+// Save takes a sessions.SessionState and stores the information from it
+// to redies, and adds a new ticket cookie on the HTTP response writer
+func (store *SessionStore) Save(rw http.ResponseWriter, req *http.Request, s *sessions.SessionState) error {
+	requestCookie, _ := req.Cookie(store.CookieName)
+	value, err := s.EncodeSessionState(store.CookieCipher)
+	if err != nil {
+		return err
+	}
+	ticketString, err := store.storeValue(value, s.ExpiresOn, requestCookie)
+	if err != nil {
+		return err
+	}
+
+	ticketCookie := cookies.MakeCookie(
+		req,
+		store.CookieName,
+		ticketString,
+		store.CookiePath,
+		store.CookieDomain,
+		store.CookieHTTPOnly,
+		store.CookieSecure,
+		store.CookieExpire,
+		time.Now(),
+	)
+
+	http.SetCookie(rw, ticketCookie)
+	return nil
+}
+
+// Load reads sessions.SessionState information from a ticket
+// cookie within the HTTP request object
+func (store *SessionStore) Load(req *http.Request) (*sessions.SessionState, error) {
+	requestCookie, _ := req.Cookie(store.CookieName)
+	// No cookie validation necessary
+	session, err := store.LoadSessionFromString(requestCookie.Value)
+	if err != nil {
+		return nil, fmt.Errorf("error loading session: %s", err)
+	}
+	return session, nil
+}
+
+// LoadSessionFromString loads the session based on the ticket value
+func (store *SessionStore) LoadSessionFromString(value string) (*sessions.SessionState, error) {
+	ticket, err := decodeTicket(store.CookieName, value)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := store.Client.Get(ticket.asHandle(store.CookieName)).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	resultBytes := []byte(result)
+	block, err := aes.NewCipher(ticket.Secret)
+	if err != nil {
+		return nil, err
+	}
+	// Use secret as the IV too, because each entry has it's own key
+	stream := cipher.NewCFBDecrypter(block, ticket.Secret)
+	stream.XORKeyStream(resultBytes, resultBytes)
+
+	session, err := sessions.DecodeSessionState(string(resultBytes), store.CookieCipher)
+	if err != nil {
+		return nil, err
+	}
+	return session, nil
+}
+
+// Clear clears any saved session information for a given ticket cookie
+// from redis, and then clears the session
+func (store *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) error {
+	requestCookie, _ := req.Cookie(store.CookieName)
+
+	// We go ahead and clear the cookie first, always.
+	clearCookie := cookies.MakeCookie(
+		req,
+		store.CookieName,
+		"",
+		store.CookiePath,
+		store.CookieDomain,
+		store.CookieHTTPOnly,
+		store.CookieSecure,
+		time.Hour*-1,
+		time.Now(),
+	)
+	http.SetCookie(rw, clearCookie)
+
+	// We only return an error if we had an issue with redis
+	// If there's an issue decoding the ticket, ignore it
+	ticket, _ := decodeTicket(store.CookieName, requestCookie.Value)
+	if ticket != nil {
+		deleted, err := store.Client.Del(ticket.asHandle(store.CookieName)).Result()
+		fmt.Println("delted %n", deleted)
+		if err != nil {
+			return fmt.Errorf("error clearing cookie from redis: %s", err)
+		}
+	}
+	return nil
+}
+
+func (store *SessionStore) storeValue(value string, expiresOn time.Time, requestCookie *http.Cookie) (string, error) {
+	var ticket *TicketData
+	if requestCookie != nil {
+		var err error
+		ticket, err = decodeTicket(store.CookieName, requestCookie.Value)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		var err error
+		ticket, err = newTicket()
+		if err != nil {
+			return "", fmt.Errorf("error creating new ticket: %s", err)
+		}
+	}
+
+	ciphertext := make([]byte, len(value))
+	block, err := aes.NewCipher(ticket.Secret)
+	if err != nil {
+		return "", fmt.Errorf("error initiating cipher block %s", err)
+	}
+
+	// Use secret as the IV too, because each entry has it's own key
+	stream := cipher.NewCFBEncrypter(block, ticket.Secret)
+	stream.XORKeyStream(ciphertext, []byte(value))
+
+	handle := ticket.asHandle(store.CookieName)
+	expires := expiresOn.Sub(time.Now())
+	err = store.Client.Set(handle, ciphertext, expires).Err()
+	if err != nil {
+		return "", err
+	}
+	return ticket.encodeTicket(store.CookieName), nil
+}
+
+func newTicket() (*TicketData, error) {
+	rawID := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, rawID); err != nil {
+		return nil, fmt.Errorf("failed to create new ticket ID %s", err)
+	}
+	// ticketID is hex encoded
+	ticketID := fmt.Sprintf("%x", rawID)
+
+	secret := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
+		return nil, fmt.Errorf("failed to create initialization vector %s", err)
+	}
+	ticket := &TicketData{
+		TicketID: ticketID,
+		Secret:   secret,
+	}
+	return ticket, nil
+}
+
+func (ticket *TicketData) asHandle(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, ticket.TicketID)
+}
+
+func decodeTicket(cookieName string, ticketString string) (*TicketData, error) {
+	prefix := cookieName + "-"
+	if !strings.HasPrefix(ticketString, prefix) {
+		return nil, fmt.Errorf("failed to decode ticket handle")
+	}
+	trimmedTicket := strings.TrimPrefix(ticketString, prefix)
+
+	ticketParts := strings.Split(trimmedTicket, ".")
+	if len(ticketParts) != 2 {
+		return nil, fmt.Errorf("failed to decode ticket")
+	}
+	ticketID, secretBase64 := ticketParts[0], ticketParts[1]
+
+	// ticketID must be a hexadecimal string
+	_, err := hex.DecodeString(ticketID)
+	if err != nil {
+		return nil, fmt.Errorf("server ticket failed sanity checks")
+		// s is not a valid
+	}
+
+	secret, err := base64.RawURLEncoding.DecodeString(secretBase64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode initialization vector %s", err)
+	}
+	ticketData := &TicketData{
+		TicketID: ticketID,
+		Secret:   secret,
+	}
+	return ticketData, nil
+}
+
+func (ticket *TicketData) encodeTicket(prefix string) string {
+	handle := ticket.asHandle(prefix)
+	ticketString := handle + "." + base64.RawURLEncoding.EncodeToString(ticket.Secret)
+	return ticketString
+}

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -202,8 +202,8 @@ func (store *SessionStore) storeValue(value string, expiresOn time.Time, request
 	stream.XORKeyStream(ciphertext, []byte(value))
 
 	handle := ticket.asHandle(store.CookieOptions.CookieName)
-	expires := expiresOn.Sub(time.Now())
-	err = store.Client.Set(handle, ciphertext, expires).Err()
+	expiration := expiresOn.Sub(time.Now())
+	err = store.Client.Set(handle, ciphertext, expiration).Err()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sessions/session_store.go
+++ b/pkg/sessions/session_store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pusher/oauth2_proxy/pkg/apis/options"
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
 	"github.com/pusher/oauth2_proxy/pkg/sessions/cookie"
+	"github.com/pusher/oauth2_proxy/pkg/sessions/redis"
 )
 
 // NewSessionStore creates a SessionStore from the provided configuration
@@ -13,6 +14,8 @@ func NewSessionStore(opts *options.SessionOptions, cookieOpts *options.CookieOpt
 	switch opts.Type {
 	case options.CookieSessionStoreType:
 		return cookie.NewCookieSessionStore(opts, cookieOpts)
+	case options.RedisSessionStoreType:
+		return redis.NewRedisSessionStore(opts.RedisStoreOptions, cookieOpts)
 	default:
 		return nil, fmt.Errorf("unknown session store type '%s'", opts.Type)
 	}

--- a/pkg/sessions/session_store.go
+++ b/pkg/sessions/session_store.go
@@ -15,7 +15,7 @@ func NewSessionStore(opts *options.SessionOptions, cookieOpts *options.CookieOpt
 	case options.CookieSessionStoreType:
 		return cookie.NewCookieSessionStore(opts, cookieOpts)
 	case options.RedisSessionStoreType:
-		return redis.NewRedisSessionStore(opts.RedisStoreOptions, cookieOpts)
+		return redis.NewRedisSessionStore(opts, cookieOpts)
 	default:
 		return nil, fmt.Errorf("unknown session store type '%s'", opts.Type)
 	}

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -122,7 +122,7 @@ var _ = Describe("NewSessionStore", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("sets a `set-cookie` header in the response and session to not be loadable after clear", func() {
+			It("sets a `set-cookie` header in the response", func() {
 				Expect(response.Header().Get("Set-Cookie")).ToNot(BeEmpty())
 			})
 
@@ -169,8 +169,9 @@ var _ = Describe("NewSessionStore", func() {
 		})
 	}
 
+	// The following should only be for server stores
 	PersistentSessionStoreTests := func() {
-		Context("when Clear is called the session should not be recoverable", func() {
+		Context("when Clear is called on a persistent store", func() {
 			var loadedAfterClear *sessionsapi.SessionState
 			BeforeEach(func() {
 				req := httptest.NewRequest("GET", "http://example.com/", nil)
@@ -185,16 +186,21 @@ var _ = Describe("NewSessionStore", func() {
 				err = ss.Clear(response, request)
 				Expect(err).ToNot(HaveOccurred())
 
-				// The following should only be for server stores
 				loadReq := httptest.NewRequest("GET", "http://example.com/", nil)
 				for _, c := range resultCookies {
 					loadReq.AddCookie(c)
 				}
+
 				loadedAfterClear, err = ss.Load(loadReq)
+				// If we have cleared the session, Load should fail
+				Expect(err).To(HaveOccurred())
 			})
 
-			It("sets a `set-cookie` header in the response and session to not be loadable after clear", func() {
+			It("sets a `set-cookie` header in the response", func() {
 				Expect(response.Header().Get("Set-Cookie")).ToNot(BeEmpty())
+			})
+
+			It("attempting to Load returns an empty session", func() {
 				Expect(loadedAfterClear).To(BeNil())
 			})
 

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -115,8 +115,9 @@ var _ = Describe("NewSessionStore", func() {
 				err := ss.Save(saveResp, req, session)
 				Expect(err).ToNot(HaveOccurred())
 
-				resultCookie := saveResp.Result().Cookies()[0]
-				request.AddCookie(resultCookie)
+				for _, c := range saveResp.Result().Cookies() {
+					request.AddCookie(c)
+				}
 				err = ss.Clear(response, request)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -177,14 +178,18 @@ var _ = Describe("NewSessionStore", func() {
 				err := ss.Save(saveResp, req, session)
 				Expect(err).ToNot(HaveOccurred())
 
-				resultCookie := saveResp.Result().Cookies()[0]
-				request.AddCookie(resultCookie)
+				resultCookies := saveResp.Result().Cookies()
+				for _, c := range resultCookies {
+					request.AddCookie(c)
+				}
 				err = ss.Clear(response, request)
 				Expect(err).ToNot(HaveOccurred())
 
 				// The following should only be for server stores
 				loadReq := httptest.NewRequest("GET", "http://example.com/", nil)
-				loadReq.AddCookie(resultCookie)
+				for _, c := range resultCookies {
+					loadReq.AddCookie(c)
+				}
 				loadedAfterClear, err = ss.Load(loadReq)
 			})
 

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -306,13 +306,17 @@ var _ = Describe("NewSessionStore", func() {
 	})
 
 	Context("with type 'redis'", func() {
+		var mr *miniredis.Miniredis
 		BeforeEach(func() {
-			mr, err := miniredis.Run()
-			if err != nil {
-				panic(err)
-			}
+			var err error
+			mr, err = miniredis.Run()
+			Expect(err).ToNot(HaveOccurred())
 			opts.Type = options.RedisSessionStoreType
 			opts.RedisConnectionURL = "redis://" + mr.Addr()
+		})
+
+		AfterEach(func() {
+			mr.Close()
 		})
 
 		It("creates a redis.SessionStore", func() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implements a redis-backed session store.
Cookies are implemented as tickets.

A ticket is composed of:

`{CookieName}-{ticketID}.{secret}`

Where:
* the `CookieName` is the OAuth2 cookie name (`_oauth2_proxy` by default)
* the `ticketID` is a 128 bit random number, hex-encoded
* the `secret` is a 128 bit random number, base64 encoded

The pair of `{CookieName}-{ticketID}` comprises a ticket handle, and thus, the redis key. The handle is used to store an encoded session in redis via `SETEX`. The encoded session is encrypted according to the `secret`, which is unique for every session. This preserves the security aspects of oauth2_proxy.

## Motivation and Context

#138

## How Has This Been Tested?

The session storage has been added to the suites for a session store. An additional behavior has been added to ensure the behavior that persistent keys, when cleared, are actually cleared.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
