### PR TITLE
Add make targets for serving docs locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ release
 .godeps
 *.exe
 .env
+.bundle
 
 # Go.gitignore
 # Compiled Object files, Static and Dynamic libs (Shared Objects)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,18 @@
+.PHONY: ruby
+ruby:
+	@ if [ ! $$(which ruby) ]; then \
+			echo "Please install ruby version 2.1.0 or higher"; \
+		fi
+
+.PHONY: bundle
+bundle: ruby
+	@ if [ ! $$(which bundle) ]; then \
+			echo "Please install bundle: `gem install bundler`"; \
+		fi
+
+vendor/bundle: bundle
+	bundle install --path vendor/bundle
+
+.PHONY: serve
+serve: vendor/bundle
+	bundle exec jekyll serve

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Docs
+
+This folder contains our Jekyll based docs site which is hosted at
+https://pusher.github.io/oauth2_proxy.
+
+When making changes to this docs site, please test your changes locally:
+
+```bash
+make serve
+```
+
+To run the docs site locally you will need Ruby at version 2.1.0 or
+higher and `bundle` (`gem install bundler` if you already have Ruby).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #151

Adds a `make serve` target and readme to the docs folder to let users know they can test their docs changes locally

## Motivation and Context

It should be easy to test locally

## How Has This Been Tested?

Manually ran on my machine and seemed to work

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
