### PR TITLE
Drop Go 1.11 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.11.x
   - 1.12.x
 install:
   # Fetch dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Changes since v3.2.0
 
+- [#168](https://github.com/pusher/outh2_proxy/pull/168) Drop Go 1.11 support in Travis (@JoelSpeed)
 - [#169](https://github.com/pusher/outh2_proxy/pull/169) Update Alpine to 3.9 (@kskewes)
 - [#148](https://github.com/pusher/outh2_proxy/pull/148) Implement SessionStore interface within proxy (@JoelSpeed)
 - [#147](https://github.com/pusher/outh2_proxy/pull/147) Add SessionStore interfaces and initial implementation (@JoelSpeed)

--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ check_for() {
 check_go_version() {
   echo -n "Checking go version... "
   GO_VERSION=$(${tools[go]} version | ${tools[awk]} '{where = match($0, /[0-9]\.[0-9]+\.[0-9]*/); if (where != 0) print substr($0, RSTART, RLENGTH)}')
-  vercomp $GO_VERSION 1.11
+  vercomp $GO_VERSION 1.12
   case $? in
     0) ;&
     1)
@@ -91,7 +91,7 @@ check_go_version() {
       ;;
     2)
       printf "${RED}"
-      echo "$GO_VERSION < 1.11"
+      echo "$GO_VERSION < 1.12"
       exit 1
       ;;
   esac


### PR DESCRIPTION
## Description

Drop testing of OAuth2 Proxy against Go 1.11

## Motivation and Context

Go 1.11 is slow and constantly times out for our CI. We test against 1.12, I see little point testing against multiple versions.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
