### PR TITLE
Bump go-oidc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Changes since v3.2.0
 
+- [#175](https://github.com/pusher/outh2_proxy/pull/175) Bump go-oidc to v2.0.0 (@aeijdenberg).
+  - Includes fix for potential signature checking issue when OIDC discovery is skipped.
 - [#168](https://github.com/pusher/outh2_proxy/pull/168) Drop Go 1.11 support in Travis (@JoelSpeed)
 - [#169](https://github.com/pusher/outh2_proxy/pull/169) Update Alpine to 3.9 (@kskewes)
 - [#148](https://github.com/pusher/outh2_proxy/pull/148) Implement SessionStore interface within proxy (@JoelSpeed)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,12 +26,12 @@
   version = "v0.5.0"
 
 [[projects]]
-  branch = "v2"
-  digest = "1:e5a238f8fa890e529d7e493849bbae8988c9e70344e4630cc4f9a11b00516afb"
+  digest = "1:d8ee1b165eb7f4fd9ada718e1e7eeb0bc1fd462592d0bd823df694443f448681"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
   pruneopts = ""
-  revision = "77e7f2010a464ade7338597afe650dfcffbe2ca8"
+  revision = "1180514eaf4d9f38d0d19eef639a1d695e066e72"
+  version = "v2.0.0"
 
 [[projects]]
   digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,7 @@
   version = "~0.5.0"
 
 [[constraint]]
-  branch = "v2"
+  version = "^2"
   name = "github.com/coreos/go-oidc"
 
 [[constraint]]


### PR DESCRIPTION
## Description

Latest `go-oidc` contains https://github.com/coreos/go-oidc/commit/20c0c224c7102089f94a9c11a80e66fe873f3eb9 which ensures that the `SupportedSigningAlgs` is never empty.

## Motivation and Context

If `-skip-oidc-discovery` / `OAUTH2_SKIP_OIDC_DISCOVERY` / `skip_oidc_discovery` is set, then this [codepath](https://github.com/pusher/oauth2_proxy/blob/master/options.go#L226) will create a verifier with no signature algorithms set. With previous versions of `go-oidc`, that would [skip checking](https://github.com/coreos/go-oidc/blob/77e7f2010a464ade7338597afe650dfcffbe2ca8/verify.go#L228) if the `alg` is in a whitelist, which may allow the infamous `none` algorithm be evaluated.

## How Has This Been Tested?

I haven't tried to exploit this, it just stood out while reviewing this code for common errors - and given that generally during an `authorization_code` flow the token is fetched directly from the IdP, rather than accepted from users via a header (and due to other reasons listed in the `go-oidc` commit), it may not easily be exploitable, but still should be fixed, since it's easy.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
