### PR TITLE
Stop assuming that GOPATH is always set, and is a single directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ install:
   - wget -O dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
   - chmod +x dep
   - mv dep $GOPATH/bin/dep
+  - go get github.com/alecthomas/gometalinter
+  - gometalinter --install
 script:
   - ./configure && make test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ install:
   - chmod +x dep
   - mv dep $GOPATH/bin/dep
 script:
-  - ./configure
-  # Run tests
-  - make test
+  - ./configure && make test
 sudo: false
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,8 @@ clean:
 distclean: clean
 	rm -rf vendor
 
-BIN_DIR := $(GOPATH)/bin
-GOMETALINTER := $(BIN_DIR)/gometalinter
-
-$(GOMETALINTER):
-	$(GO) get -u github.com/alecthomas/gometalinter
-	gometalinter --install %> /dev/null
-
 .PHONY: lint
-lint: $(GOMETALINTER)
+lint:
 	$(GOMETALINTER) --vendor --disable-all \
 		--enable=vet \
 		--enable=vetshadow \

--- a/configure
+++ b/configure
@@ -126,6 +126,7 @@ check_for go
 check_go_version
 check_go_env
 check_for dep
+check_for gometalinter
 
 echo
 
@@ -134,6 +135,7 @@ cat <<- EOF > .env
   GO := "${tools[go]}"
   GO_VERSION := ${tools[go_version]}
   DEP := "${tools[dep]}"
+  GOMETALINTER := "${tools[gometalinter]}"
 EOF
 
 echo "Environment configuration written to .env"


### PR DESCRIPTION
## Description

Current `Makefile` tries to always install `gometalinter` to your `GOPATH`, which fails if it is not set, or is set to multiple entries.

## Motivation and Context

As of I think go1.8 `GOPATH` is by default `$HOME/go` so it is incorrect to
assume that it is set at all.

If not set, then the `Makefile` assumes **gometalinter** will be in
`/bin/gometalinter`, which it likely is not, and thus fails.

We could change configure to set `GOPATH` in the `.env`, however then we
would be assuming that `GOPATH` is a single entry - whereas like other
paths, it can contain more than one value.

So instead this commit stops trying to install `gometalinter`, and like
`dep`, it assumes that it is installed prior.

(and since the current behaviour of the `Makefile` is affecting state
external to the project, that seems more logical)


## How Has This Been Tested?

`make release` still works if `gometalinter` is installed, and `./configure` fails with:

```
Checking for gometalinter... not found
```

if it is not.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
