### PR TITLE
Add silence-ping-logging flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ## Changes since v3.2.0
 
-- [#178](https://github.com/pusher/outh2_proxy/pull/178) Add silence ping logging and exclude logging paths flags (@kskewes)
+- [#178](https://github.com/pusher/outh2_proxy/pull/178) Add Silence Ping Logging and Exclude Logging Paths flags (@kskewes)
 - [#209](https://github.com/pusher/outh2_proxy/pull/209) Improve docker build caching of layers (@dekimsey)
 - [#186](https://github.com/pusher/oauth2_proxy/pull/186) Make config consistent (@JoelSpeed)
 - [#187](https://github.com/pusher/oauth2_proxy/pull/187) Move root packages to pkg folder (@JoelSpeed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ## Changes since v3.2.0
 
+- [#178](https://github.com/pusher/outh2_proxy/pull/178) Add silence ping logging and exclude logging paths flags (@kskewes)
 - [#209](https://github.com/pusher/outh2_proxy/pull/209) Improve docker build caching of layers (@dekimsey)
 - [#186](https://github.com/pusher/oauth2_proxy/pull/186) Make config consistent (@JoelSpeed)
 - [#187](https://github.com/pusher/oauth2_proxy/pull/187) Move root packages to pkg folder (@JoelSpeed)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -74,6 +74,7 @@ Usage of oauth2_proxy:
   -pass-user-headers: pass X-Forwarded-User and X-Forwarded-Email information to upstream (default true)
   -profile-url string: Profile access endpoint
   -provider string: OAuth provider (default "google")
+  -ping-path string: the ping endpoint that can be used for basic health checks (default "/ping")
   -proxy-prefix string: the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in) (default "/oauth2")
   -proxy-websockets: enables WebSocket proxying (default true)
   -pubjwk-url string: JWK pubkey access endpoint: required by login.gov
@@ -91,6 +92,7 @@ Usage of oauth2_proxy:
   -set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
   -set-authorization-header: set Authorization Bearer response header (useful in Nginx auth_request mode)
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
+  -silence-ping-logging bool: disable logging of requests to ping endpoint (default false) 
   -skip-auth-preflight: will skip authentication for OPTIONS requests
   -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)
   -skip-jwt-bearer-tokens: will skip requests that have verified JWT bearer tokens
@@ -140,7 +142,7 @@ There are three different types of logging: standard, authentication, and HTTP r
 
 Each type of logging has their own configurable format and variables. By default these formats are similar to the Apache Combined Log.
 
-A specific path can be excluded from request logs by setting `-exclude-logging-path`. This is useful for disabling logging of requests to the `/ping` endpoint to reduce log volume when health checking `oauth2_proxy`.
+Logging of requests to the `/ping` endpoint can be disabled with `-silence-ping-logging` reducing log volume. This flag sets the `-exclude-logging-path` value to the `-ping-path` and takes precedence over any other value `-exclude-logging-path` may have been set to directly.
 
 ### Auth Log Format
 Authentication logs are logs which are guaranteed to contain a username or email address of a user attempting to authenticate. These logs are output by default in the below format:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -41,8 +41,9 @@ Usage of oauth2_proxy:
   -custom-templates-dir string: path to custom html templates
   -display-htpasswd-form: display username / password login form if an htpasswd file is provided (default true)
   -email-domain value: authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
+<<<<<<< HEAD
   -extra-jwt-issuers: if -skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)
-  -exclude-logging-path: don't log requests to this path, eg: /ping (default "" = no paths excluded)
+  -exclude-logging-paths: comma separated list of paths to exclude from logging, eg: "/ping,/path2" (default "" = no paths excluded)
   -flush-interval: period between flushing response buffers when streaming responses (default "1s")
   -banner string: custom banner string. Use "-" to disable default banner.
   -footer string: custom footer string. Use "-" to disable default footer.
@@ -142,7 +143,7 @@ There are three different types of logging: standard, authentication, and HTTP r
 
 Each type of logging has their own configurable format and variables. By default these formats are similar to the Apache Combined Log.
 
-Logging of requests to the `/ping` endpoint can be disabled with `-silence-ping-logging` reducing log volume. This flag sets the `-exclude-logging-path` value to the `-ping-path` and takes precedence over any other value `-exclude-logging-path` may have been set to directly.
+Logging of requests to the `/ping` endpoint can be disabled with `-silence-ping-logging` reducing log volume. This flag appends the `-ping-path` to `-exclude-logging-paths`.
 
 ### Auth Log Format
 Authentication logs are logs which are guaranteed to contain a username or email address of a user attempting to authenticate. These logs are output by default in the below format:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -41,7 +41,6 @@ Usage of oauth2_proxy:
   -custom-templates-dir string: path to custom html templates
   -display-htpasswd-form: display username / password login form if an htpasswd file is provided (default true)
   -email-domain value: authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
-<<<<<<< HEAD
   -extra-jwt-issuers: if -skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)
   -exclude-logging-paths: comma separated list of paths to exclude from logging, eg: "/ping,/path2" (default "" = no paths excluded)
   -flush-interval: period between flushing response buffers when streaming responses (default "1s")

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -90,6 +90,7 @@ Usage of oauth2_proxy:
   -set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
   -set-authorization-header: set Authorization Bearer response header (useful in Nginx auth_request mode)
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
+  -silence-ping-logging bool: disable logging of requests to ping endpoint (default false) 
   -skip-auth-preflight: will skip authentication for OPTIONS requests
   -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)
   -skip-jwt-bearer-tokens: will skip requests that have verified JWT bearer tokens
@@ -138,6 +139,8 @@ If logging to a file you can also configure the maximum file size (`-logging-max
 There are three different types of logging: standard, authentication, and HTTP requests. These can each be enabled or disabled with `-standard-logging`, `-auth-logging`, and `-request-logging`.
 
 Each type of logging has their own configurable format and variables. By default these formats are similar to the Apache Combined Log.
+
+Logging of requests to the `/ping` endpoint can be disabled with `-silence-ping-logging` reducing log volume.
 
 ### Auth Log Format
 Authentication logs are logs which are guaranteed to contain a username or email address of a user attempting to authenticate. These logs are output by default in the below format:

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -42,6 +42,7 @@ Usage of oauth2_proxy:
   -display-htpasswd-form: display username / password login form if an htpasswd file is provided (default true)
   -email-domain value: authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
   -extra-jwt-issuers: if -skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)
+  -exclude-logging-path: don't log requests to this path, eg: /ping (default "" = no paths excluded)
   -flush-interval: period between flushing response buffers when streaming responses (default "1s")
   -banner string: custom banner string. Use "-" to disable default banner.
   -footer string: custom footer string. Use "-" to disable default footer.
@@ -90,7 +91,6 @@ Usage of oauth2_proxy:
   -set-xauthrequest: set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)
   -set-authorization-header: set Authorization Bearer response header (useful in Nginx auth_request mode)
   -signature-key string: GAP-Signature request signature key (algorithm:secretkey)
-  -silence-ping-logging bool: disable logging of requests to ping endpoint (default false) 
   -skip-auth-preflight: will skip authentication for OPTIONS requests
   -skip-auth-regex value: bypass authentication for requests path's that match (may be given multiple times)
   -skip-jwt-bearer-tokens: will skip requests that have verified JWT bearer tokens
@@ -140,7 +140,7 @@ There are three different types of logging: standard, authentication, and HTTP r
 
 Each type of logging has their own configurable format and variables. By default these formats are similar to the Apache Combined Log.
 
-Logging of requests to the `/ping` endpoint can be disabled with `-silence-ping-logging` reducing log volume.
+A specific path can be excluded from request logs by setting `-exclude-logging-path`. This is useful for disabling logging of requests to the `/ping` endpoint to reduce log volume when health checking `oauth2_proxy`.
 
 ### Auth Log Format
 Authentication logs are logs which are guaranteed to contain a username or email address of a user attempting to authenticate. These logs are output by default in the below format:

--- a/logging_handler.go
+++ b/logging_handler.go
@@ -75,18 +75,19 @@ func (l *responseLogger) Status() int {
 	return l.status
 }
 
-// Size returns teh response size
+// Size returns the response size
 func (l *responseLogger) Size() int {
 	return l.size
 }
 
+// Flush sends any buffered data to the client
 func (l *responseLogger) Flush() {
 	if flusher, ok := l.w.(http.Flusher); ok {
 		flusher.Flush()
 	}
 }
 
-// loggingHandler is the http.Handler implementation for LoggingHandlerTo and its friends
+// loggingHandler is the http.Handler implementation for LoggingHandler
 type loggingHandler struct {
 	handler http.Handler
 }

--- a/logging_handler_test.go
+++ b/logging_handler_test.go
@@ -24,6 +24,7 @@ func TestLoggingHandler_ServeHTTP(t *testing.T) {
 		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", ""},
 		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", "/ping"},
 		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/ping\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/ping", ""},
+		{logger.DefaultRequestLoggingFormat, "", "/ping", "/ping"},
 		{"{{.RequestMethod}}", "GET\n", "/foo/bar", ""},
 		{"{{.RequestMethod}}", "GET\n", "/foo/bar", "/ping"},
 		{"{{.RequestMethod}}", "GET\n", "/ping", ""},

--- a/logging_handler_test.go
+++ b/logging_handler_test.go
@@ -19,15 +19,15 @@ func TestLoggingHandler_ServeHTTP(t *testing.T) {
 		Format,
 		ExpectedLogMessage,
 		Path string
-		SilentPing bool
+		ExcludePath string
 	}{
-		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", false},
-		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", true},
-		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/ping\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/ping", false},
-		{"{{.RequestMethod}}", "GET\n", "/foo/bar", false},
-		{"{{.RequestMethod}}", "GET\n", "/foo/bar", true},
-		{"{{.RequestMethod}}", "GET\n", "/ping", false},
-		{"{{.RequestMethod}}", "", "/ping", true},
+		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", ""},
+		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", "/ping"},
+		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/ping\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/ping", ""},
+		{"{{.RequestMethod}}", "GET\n", "/foo/bar", ""},
+		{"{{.RequestMethod}}", "GET\n", "/foo/bar", "/ping"},
+		{"{{.RequestMethod}}", "GET\n", "/ping", ""},
+		{"{{.RequestMethod}}", "", "/ping", "/ping"},
 	}
 
 	for _, test := range tests {
@@ -43,7 +43,7 @@ func TestLoggingHandler_ServeHTTP(t *testing.T) {
 
 		logger.SetOutput(buf)
 		logger.SetReqTemplate(test.Format)
-		logger.SetSilentPing(test.SilentPing)
+		logger.SetExcludePath(test.ExcludePath)
 		h := LoggingHandler(http.HandlerFunc(handler))
 
 		r, _ := http.NewRequest("GET", test.Path, nil)

--- a/logging_handler_test.go
+++ b/logging_handler_test.go
@@ -19,16 +19,21 @@ func TestLoggingHandler_ServeHTTP(t *testing.T) {
 		Format,
 		ExpectedLogMessage,
 		Path string
-		ExcludePath string
+		ExcludePaths       []string
+		SilencePingLogging bool
 	}{
-		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", ""},
-		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", "/ping"},
-		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/ping\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/ping", ""},
-		{logger.DefaultRequestLoggingFormat, "", "/ping", "/ping"},
-		{"{{.RequestMethod}}", "GET\n", "/foo/bar", ""},
-		{"{{.RequestMethod}}", "GET\n", "/foo/bar", "/ping"},
-		{"{{.RequestMethod}}", "GET\n", "/ping", ""},
-		{"{{.RequestMethod}}", "", "/ping", "/ping"},
+		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", []string{}, false},
+		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", []string{}, true},
+		{logger.DefaultRequestLoggingFormat, fmt.Sprintf("127.0.0.1 - - [%s] test-server GET - \"/foo/bar\" HTTP/1.1 \"\" 200 4 0.000\n", logger.FormatTimestamp(ts)), "/foo/bar", []string{"/ping"}, false},
+		{logger.DefaultRequestLoggingFormat, "", "/foo/bar", []string{"/foo/bar"}, false},
+		{logger.DefaultRequestLoggingFormat, "", "/ping", []string{}, true},
+		{logger.DefaultRequestLoggingFormat, "", "/ping", []string{"/ping"}, false},
+		{logger.DefaultRequestLoggingFormat, "", "/ping", []string{"/ping"}, true},
+		{logger.DefaultRequestLoggingFormat, "", "/ping", []string{"/foo/bar", "/ping"}, false},
+		{"{{.RequestMethod}}", "GET\n", "/foo/bar", []string{}, true},
+		{"{{.RequestMethod}}", "GET\n", "/foo/bar", []string{"/ping"}, false},
+		{"{{.RequestMethod}}", "GET\n", "/ping", []string{}, false},
+		{"{{.RequestMethod}}", "", "/ping", []string{"/ping"}, true},
 	}
 
 	for _, test := range tests {
@@ -44,7 +49,10 @@ func TestLoggingHandler_ServeHTTP(t *testing.T) {
 
 		logger.SetOutput(buf)
 		logger.SetReqTemplate(test.Format)
-		logger.SetExcludePath(test.ExcludePath)
+		if test.SilencePingLogging {
+			test.ExcludePaths = append(test.ExcludePaths, "/ping")
+		}
+		logger.SetExcludePaths(test.ExcludePaths)
 		h := LoggingHandler(http.HandlerFunc(handler))
 
 		r, _ := http.NewRequest("GET", test.Path, nil)

--- a/main.go
+++ b/main.go
@@ -32,8 +32,8 @@ func main() {
 
 	flagSet.String("http-address", "127.0.0.1:4180", "[http://]<addr>:<port> or unix://<path> to listen on for HTTP clients")
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
-	flagSet.String("tls-cert", "", "path to certificate file")
-	flagSet.String("tls-key", "", "path to private key file")
+	flagSet.String("tls-cert-file", "", "path to certificate file")
+	flagSet.String("tls-key-file", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 
 	flagSet.Bool("request-logging", true, "Log HTTP requests")
 	flagSet.String("request-logging-format", logger.DefaultRequestLoggingFormat, "Template for HTTP request log lines")
-	flagSet.Bool("silence-ping-logging", false, "Disable logging of requests to ping endpoint")
+	flagSet.String("exclude-logging-path", "", "Exclude logging requests to path (eg: /ping)")
 
 	flagSet.Bool("auth-logging", true, "Log authentication attempts")
 	flagSet.String("auth-logging-format", logger.DefaultAuthLoggingFormat, "Template for authentication log lines")

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 	flagSet.String("banner", "", "custom banner string. Use \"-\" to disable default banner.")
 	flagSet.String("footer", "", "custom footer string. Use \"-\" to disable default footer.")
 	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
+	flagSet.String("ping-path", "/ping", "the ping endpoint that can be used for basic health checks")
 	flagSet.Bool("proxy-websockets", true, "enables WebSocket proxying")
 
 	flagSet.String("cookie-name", "_oauth2_proxy", "the name of the cookie that the oauth_proxy creates")
@@ -99,6 +100,7 @@ func main() {
 	flagSet.Bool("request-logging", true, "Log HTTP requests")
 	flagSet.String("request-logging-format", logger.DefaultRequestLoggingFormat, "Template for HTTP request log lines")
 	flagSet.String("exclude-logging-path", "", "Exclude logging requests to path (eg: /ping)")
+	flagSet.Bool("silence-ping-logging", false, "Disable logging of requests to ping endpoint")
 
 	flagSet.Bool("auth-logging", true, "Log authentication attempts")
 	flagSet.String("auth-logging-format", logger.DefaultAuthLoggingFormat, "Template for authentication log lines")

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 
 	flagSet.Bool("request-logging", true, "Log HTTP requests")
 	flagSet.String("request-logging-format", logger.DefaultRequestLoggingFormat, "Template for HTTP request log lines")
+	flagSet.Bool("silence-ping-logging", false, "Disable logging of requests to ping endpoint")
 
 	flagSet.Bool("auth-logging", true, "Log authentication attempts")
 	flagSet.String("auth-logging-format", logger.DefaultAuthLoggingFormat, "Template for authentication log lines")

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 
 	flagSet.Bool("request-logging", true, "Log HTTP requests")
 	flagSet.String("request-logging-format", logger.DefaultRequestLoggingFormat, "Template for HTTP request log lines")
-	flagSet.String("exclude-logging-path", "", "Exclude logging requests to path (eg: /ping)")
+	flagSet.String("exclude-logging-paths", "", "Exclude logging requests to paths (eg: '/path1,/path2,/path3')")
 	flagSet.Bool("silence-ping-logging", false, "Disable logging of requests to ping endpoint")
 
 	flagSet.Bool("auth-logging", true, "Log authentication attempts")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -254,7 +254,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		Validator:      validator,
 
 		RobotsPath:        "/robots.txt",
-		PingPath:          "/ping",
+		PingPath:          opts.PingPath,
 		SignInPath:        fmt.Sprintf("%s/sign_in", opts.ProxyPrefix),
 		SignOutPath:       fmt.Sprintf("%s/sign_out", opts.ProxyPrefix),
 		OAuthStartPath:    fmt.Sprintf("%s/start", opts.ProxyPrefix),

--- a/options.go
+++ b/options.go
@@ -104,7 +104,7 @@ type Options struct {
 	StandardLoggingFormat string `flag:"standard-logging-format" cfg:"standard_logging_format" env:"OAUTH2_PROXY_STANDARD_LOGGING_FORMAT"`
 	RequestLogging        bool   `flag:"request-logging" cfg:"request_logging" env:"OAUTH2_PROXY_REQUEST_LOGGING"`
 	RequestLoggingFormat  string `flag:"request-logging-format" cfg:"request_logging_format" env:"OAUTH2_PROXY_REQUEST_LOGGING_FORMAT"`
-	ExcludeLoggingPaths   string `flag:"exclude-logging-paths" cfg:"exclude_logging_paths" env:"OAUTH2_EXCLUDE_LOGGING_PATHS"`
+	ExcludeLoggingPaths   string `flag:"exclude-logging-paths" cfg:"exclude_logging_paths" env:"OAUTH2_PROXY_EXCLUDE_LOGGING_PATHS"`
 	SilencePingLogging    bool   `flag:"silence-ping-logging" cfg:"silence_ping_logging" env:"OAUTH2_PROXY_SILENCE_PING_LOGGING"`
 	AuthLogging           bool   `flag:"auth-logging" cfg:"auth_logging" env:"OAUTH2_PROXY_LOGGING_AUTH_LOGGING"`
 	AuthLoggingFormat     string `flag:"auth-logging-format" cfg:"auth_logging_format" env:"OAUTH2_PROXY_AUTH_LOGGING_FORMAT"`

--- a/options.go
+++ b/options.go
@@ -104,7 +104,7 @@ type Options struct {
 	StandardLoggingFormat string `flag:"standard-logging-format" cfg:"standard_logging_format" env:"OAUTH2_PROXY_STANDARD_LOGGING_FORMAT"`
 	RequestLogging        bool   `flag:"request-logging" cfg:"request_logging" env:"OAUTH2_PROXY_REQUEST_LOGGING"`
 	RequestLoggingFormat  string `flag:"request-logging-format" cfg:"request_logging_format" env:"OAUTH2_PROXY_REQUEST_LOGGING_FORMAT"`
-	ExcludeLoggingPath    string `flag:"exclude-logging-path" cfg:"exclude_logging_path" env:"OAUTH2_PROXY_EXCLUDE_LOGGING_PATH"`
+	ExcludeLoggingPaths   string `flag:"exclude-logging-paths" cfg:"exclude_logging_paths" env:"OAUTH2_EXCLUDE_LOGGING_PATHS"`
 	SilencePingLogging    bool   `flag:"silence-ping-logging" cfg:"silence_ping_logging" env:"OAUTH2_PROXY_SILENCE_PING_LOGGING"`
 	AuthLogging           bool   `flag:"auth-logging" cfg:"auth_logging" env:"OAUTH2_PROXY_LOGGING_AUTH_LOGGING"`
 	AuthLoggingFormat     string `flag:"auth-logging-format" cfg:"auth_logging_format" env:"OAUTH2_PROXY_AUTH_LOGGING_FORMAT"`
@@ -168,7 +168,7 @@ func NewOptions() *Options {
 		LoggingMaxBackups:                0,
 		LoggingLocalTime:                 true,
 		LoggingCompress:                  false,
-		ExcludeLoggingPath:               "",
+		ExcludeLoggingPaths:              "",
 		SilencePingLogging:               false,
 		StandardLogging:                  true,
 		StandardLoggingFormat:            logger.DefaultStandardLoggingFormat,
@@ -576,11 +576,13 @@ func setupLogger(o *Options, msgs []string) []string {
 	logger.SetAuthTemplate(o.AuthLoggingFormat)
 	logger.SetReqTemplate(o.RequestLoggingFormat)
 
+	excludePaths := make([]string, 0)
+	excludePaths = append(excludePaths, strings.Split(o.ExcludeLoggingPaths, ",")...)
 	if o.SilencePingLogging {
-		logger.SetExcludePath(o.PingPath)
-	} else {
-		logger.SetExcludePath(o.ExcludeLoggingPath)
+		excludePaths = append(excludePaths, o.PingPath)
 	}
+
+	logger.SetExcludePaths(excludePaths)
 
 	if !o.LoggingLocalTime {
 		logger.SetFlags(logger.Flags() | logger.LUTC)

--- a/options.go
+++ b/options.go
@@ -30,7 +30,7 @@ import (
 // or Config File
 type Options struct {
 	ProxyPrefix     string `flag:"proxy-prefix" cfg:"proxy_prefix" env:"OAUTH2_PROXY_PROXY_PREFIX"`
-	PingPath        string `flag:"ping-path" cfg:"ping-path" env:"OAUTH2_PROXY_PING_PATH"`
+	PingPath        string `flag:"ping-path" cfg:"ping_path" env:"OAUTH2_PROXY_PING_PATH"`
 	ProxyWebSockets bool   `flag:"proxy-websockets" cfg:"proxy_websockets" env:"OAUTH2_PROXY_PROXY_WEBSOCKETS"`
 	HTTPAddress     string `flag:"http-address" cfg:"http_address" env:"OAUTH2_PROXY_HTTP_ADDRESS"`
 	HTTPSAddress    string `flag:"https-address" cfg:"https_address" env:"OAUTH2_PROXY_HTTPS_ADDRESS"`

--- a/options.go
+++ b/options.go
@@ -103,6 +103,8 @@ type Options struct {
 	StandardLoggingFormat string `flag:"standard-logging-format" cfg:"standard_logging_format" env:"OAUTH2_PROXY_STANDARD_LOGGING_FORMAT"`
 	RequestLogging        bool   `flag:"request-logging" cfg:"request_logging" env:"OAUTH2_PROXY_REQUEST_LOGGING"`
 	RequestLoggingFormat  string `flag:"request-logging-format" cfg:"request_logging_format" env:"OAUTH2_PROXY_REQUEST_LOGGING_FORMAT"`
+	PingPath              string `flag:"ping-path" cfg:"ping_path" env:"OAUTH2_PROXY_PING_PATH"`
+	SilencePingLogging    bool   `flag:"silence-ping-logging" cfg:"silence_ping_logging" env:"OAUTH2_PROXY_SILENCE_PING_LOGGING"`
 	AuthLogging           bool   `flag:"auth-logging" cfg:"auth_logging" env:"OAUTH2_PROXY_LOGGING_AUTH_LOGGING"`
 	AuthLoggingFormat     string `flag:"auth-logging-format" cfg:"auth_logging_format" env:"OAUTH2_PROXY_AUTH_LOGGING_FORMAT"`
 
@@ -165,6 +167,8 @@ func NewOptions() *Options {
 		LoggingMaxBackups:                0,
 		LoggingLocalTime:                 true,
 		LoggingCompress:                  false,
+		PingPath:                         "/ping",
+		SilencePingLogging:               false,
 		StandardLogging:                  true,
 		StandardLoggingFormat:            logger.DefaultStandardLoggingFormat,
 		RequestLogging:                   true,
@@ -567,6 +571,8 @@ func setupLogger(o *Options, msgs []string) []string {
 	logger.SetStandardEnabled(o.StandardLogging)
 	logger.SetAuthEnabled(o.AuthLogging)
 	logger.SetReqEnabled(o.RequestLogging)
+	logger.SetSilentPing(o.SilencePingLogging)
+	logger.SetPingPath(o.PingPath)
 	logger.SetStandardTemplate(o.StandardLoggingFormat)
 	logger.SetAuthTemplate(o.AuthLoggingFormat)
 	logger.SetReqTemplate(o.RequestLoggingFormat)

--- a/options.go
+++ b/options.go
@@ -30,6 +30,7 @@ import (
 // or Config File
 type Options struct {
 	ProxyPrefix     string `flag:"proxy-prefix" cfg:"proxy_prefix" env:"OAUTH2_PROXY_PROXY_PREFIX"`
+	PingPath        string `flag:"ping-path" cfg:"ping-path" env:"OAUTH2_PROXY_PING_PATH"`
 	ProxyWebSockets bool   `flag:"proxy-websockets" cfg:"proxy_websockets" env:"OAUTH2_PROXY_PROXY_WEBSOCKETS"`
 	HTTPAddress     string `flag:"http-address" cfg:"http_address" env:"OAUTH2_PROXY_HTTP_ADDRESS"`
 	HTTPSAddress    string `flag:"https-address" cfg:"https_address" env:"OAUTH2_PROXY_HTTPS_ADDRESS"`
@@ -103,9 +104,8 @@ type Options struct {
 	StandardLoggingFormat string `flag:"standard-logging-format" cfg:"standard_logging_format" env:"OAUTH2_PROXY_STANDARD_LOGGING_FORMAT"`
 	RequestLogging        bool   `flag:"request-logging" cfg:"request_logging" env:"OAUTH2_PROXY_REQUEST_LOGGING"`
 	RequestLoggingFormat  string `flag:"request-logging-format" cfg:"request_logging_format" env:"OAUTH2_PROXY_REQUEST_LOGGING_FORMAT"`
-	PingPath              string `flag:"ping-path" cfg:"ping_path" env:"OAUTH2_PROXY_PING_PATH"`
-	SilencePingLogging    bool   `flag:"silence-ping-logging" cfg:"silence_ping_logging" env:"OAUTH2_PROXY_SILENCE_PING_LOGGING"`
 	ExcludeLoggingPath    string `flag:"exclude-logging-path" cfg:"exclude_logging_path" env:"OAUTH2_PROXY_EXCLUDE_LOGGING_PATH"`
+	SilencePingLogging    bool   `flag:"silence-ping-logging" cfg:"silence_ping_logging" env:"OAUTH2_PROXY_SILENCE_PING_LOGGING"`
 	AuthLogging           bool   `flag:"auth-logging" cfg:"auth_logging" env:"OAUTH2_PROXY_LOGGING_AUTH_LOGGING"`
 	AuthLoggingFormat     string `flag:"auth-logging-format" cfg:"auth_logging_format" env:"OAUTH2_PROXY_AUTH_LOGGING_FORMAT"`
 	SignatureKey          string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
@@ -136,6 +136,7 @@ type SignatureData struct {
 func NewOptions() *Options {
 	return &Options{
 		ProxyPrefix:         "/oauth2",
+		PingPath:            "/ping",
 		ProxyWebSockets:     true,
 		HTTPAddress:         "127.0.0.1:4180",
 		HTTPSAddress:        ":443",
@@ -168,7 +169,6 @@ func NewOptions() *Options {
 		LoggingLocalTime:                 true,
 		LoggingCompress:                  false,
 		ExcludeLoggingPath:               "",
-		PingPath:                         "/ping",
 		SilencePingLogging:               false,
 		StandardLogging:                  true,
 		StandardLoggingFormat:            logger.DefaultStandardLoggingFormat,
@@ -572,10 +572,15 @@ func setupLogger(o *Options, msgs []string) []string {
 	logger.SetStandardEnabled(o.StandardLogging)
 	logger.SetAuthEnabled(o.AuthLogging)
 	logger.SetReqEnabled(o.RequestLogging)
-	logger.SetExcludePath(o.ExcludeLoggingPath)
 	logger.SetStandardTemplate(o.StandardLoggingFormat)
 	logger.SetAuthTemplate(o.AuthLoggingFormat)
 	logger.SetReqTemplate(o.RequestLoggingFormat)
+
+	if o.SilencePingLogging {
+		logger.SetExcludePath(o.PingPath)
+	} else {
+		logger.SetExcludePath(o.ExcludeLoggingPath)
+	}
 
 	if !o.LoggingLocalTime {
 		logger.SetFlags(logger.Flags() | logger.LUTC)

--- a/options.go
+++ b/options.go
@@ -105,15 +105,15 @@ type Options struct {
 	RequestLoggingFormat  string `flag:"request-logging-format" cfg:"request_logging_format" env:"OAUTH2_PROXY_REQUEST_LOGGING_FORMAT"`
 	PingPath              string `flag:"ping-path" cfg:"ping_path" env:"OAUTH2_PROXY_PING_PATH"`
 	SilencePingLogging    bool   `flag:"silence-ping-logging" cfg:"silence_ping_logging" env:"OAUTH2_PROXY_SILENCE_PING_LOGGING"`
+	ExcludeLoggingPath    string `flag:"exclude-logging-path" cfg:"exclude_logging_path" env:"OAUTH2_PROXY_EXCLUDE_LOGGING_PATH"`
 	AuthLogging           bool   `flag:"auth-logging" cfg:"auth_logging" env:"OAUTH2_PROXY_LOGGING_AUTH_LOGGING"`
 	AuthLoggingFormat     string `flag:"auth-logging-format" cfg:"auth_logging_format" env:"OAUTH2_PROXY_AUTH_LOGGING_FORMAT"`
-
-	SignatureKey    string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
-	AcrValues       string `flag:"acr-values" cfg:"acr_values" env:"OAUTH2_PROXY_ACR_VALUES"`
-	JWTKey          string `flag:"jwt-key" cfg:"jwt_key" env:"OAUTH2_PROXY_JWT_KEY"`
-	JWTKeyFile      string `flag:"jwt-key-file" cfg:"jwt_key_file" env:"OAUTH2_PROXY_JWT_KEY_FILE"`
-	PubJWKURL       string `flag:"pubjwk-url" cfg:"pubjwk_url" env:"OAUTH2_PROXY_PUBJWK_URL"`
-	GCPHealthChecks bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks" env:"OAUTH2_PROXY_GCP_HEALTHCHECKS"`
+	SignatureKey          string `flag:"signature-key" cfg:"signature_key" env:"OAUTH2_PROXY_SIGNATURE_KEY"`
+	AcrValues             string `flag:"acr-values" cfg:"acr_values" env:"OAUTH2_PROXY_ACR_VALUES"`
+	JWTKey                string `flag:"jwt-key" cfg:"jwt_key" env:"OAUTH2_PROXY_JWT_KEY"`
+	JWTKeyFile            string `flag:"jwt-key-file" cfg:"jwt_key_file" env:"OAUTH2_PROXY_JWT_KEY_FILE"`
+	PubJWKURL             string `flag:"pubjwk-url" cfg:"pubjwk_url" env:"OAUTH2_PROXY_PUBJWK_URL"`
+	GCPHealthChecks       bool   `flag:"gcp-healthchecks" cfg:"gcp_healthchecks" env:"OAUTH2_PROXY_GCP_HEALTHCHECKS"`
 
 	// internal values that are set after config validation
 	redirectURL        *url.URL
@@ -167,6 +167,7 @@ func NewOptions() *Options {
 		LoggingMaxBackups:                0,
 		LoggingLocalTime:                 true,
 		LoggingCompress:                  false,
+		ExcludeLoggingPath:               "",
 		PingPath:                         "/ping",
 		SilencePingLogging:               false,
 		StandardLogging:                  true,
@@ -571,8 +572,7 @@ func setupLogger(o *Options, msgs []string) []string {
 	logger.SetStandardEnabled(o.StandardLogging)
 	logger.SetAuthEnabled(o.AuthLogging)
 	logger.SetReqEnabled(o.RequestLogging)
-	logger.SetSilentPing(o.SilencePingLogging)
-	logger.SetPingPath(o.PingPath)
+	logger.SetExcludePath(o.ExcludeLoggingPath)
 	logger.SetStandardTemplate(o.StandardLoggingFormat)
 	logger.SetAuthTemplate(o.AuthLoggingFormat)
 	logger.SetReqTemplate(o.RequestLoggingFormat)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -182,6 +182,7 @@ func (l *Logger) PrintReq(username, upstream string, req *http.Request, url url.
 	if url.Path == l.excludePath {
 		return
 	}
+
 	duration := float64(time.Now().Sub(ts)) / float64(time.Second)
 
 	if username == "" {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -88,8 +88,7 @@ type Logger struct {
 	stdEnabled     bool
 	authEnabled    bool
 	reqEnabled     bool
-	silentPing     bool
-	pingPath       string
+	excludePath    string
 	stdLogTemplate *template.Template
 	authTemplate   *template.Template
 	reqTemplate    *template.Template
@@ -103,8 +102,7 @@ func New(flag int) *Logger {
 		stdEnabled:     true,
 		authEnabled:    true,
 		reqEnabled:     true,
-		silentPing:     false,
-		pingPath:       "/ping",
+		excludePath:    "",
 		stdLogTemplate: template.Must(template.New("std-log").Parse(DefaultStandardLoggingFormat)),
 		authTemplate:   template.Must(template.New("auth-log").Parse(DefaultAuthLoggingFormat)),
 		reqTemplate:    template.Must(template.New("req-log").Parse(DefaultRequestLoggingFormat)),
@@ -181,7 +179,7 @@ func (l *Logger) PrintReq(username, upstream string, req *http.Request, url url.
 		return
 	}
 
-	if url.Path == l.pingPath && l.silentPing {
+	if url.Path == l.excludePath {
 		return
 	}
 	duration := float64(time.Now().Sub(ts)) / float64(time.Second)
@@ -309,18 +307,11 @@ func (l *Logger) SetReqEnabled(e bool) {
 	l.reqEnabled = e
 }
 
-// SetPingPath sets the ping path.
-func (l *Logger) SetPingPath(s string) {
+// SetExcludePath sets the path to exclude from logging.
+func (l *Logger) SetExcludePath(s string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.pingPath = s
-}
-
-// SetSilentPing disables ping request logging.
-func (l *Logger) SetSilentPing(e bool) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.silentPing = e
+	l.excludePath = s
 }
 
 // SetStandardTemplate sets the template for standard logging.
@@ -386,15 +377,9 @@ func SetReqEnabled(e bool) {
 	std.SetReqEnabled(e)
 }
 
-// SetPingPath sets the healthcheck endpoint path.
-// FIXME: Seems wrong to define this
-func SetPingPath(s string) {
-	std.SetPingPath(s)
-}
-
-// SetSilentPing disables request logging for the ping endpoint.
-func SetSilentPing(e bool) {
-	std.SetSilentPing(e)
+// SetExcludePath sets the path to exclude from logging, eg: health checks
+func SetExcludePath(s string) {
+	std.SetExcludePath(s)
 }
 
 // SetStandardTemplate sets the template for standard logging for

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -179,7 +179,7 @@ func (l *Logger) PrintReq(username, upstream string, req *http.Request, url url.
 		return
 	}
 
-	if _, excludedPath := l.excludePaths[url.Path]; excludedPath {
+	if _, ok := l.excludePaths[url.Path]; ok {
 		return
 	}
 


### PR DESCRIPTION
## Description

1. Convert hard coded ping check path `/ping` to a new `Options` `PingPath` string so its value can be passed to other functions. 
   Default remains unchanged at: `"/ping"`
2. Add new `Options` `ExcludeLoggingPaths` string to contain csv list of `url.Path`'s that should not be logged.
  Default `nil` = don't exclude any paths from logging.
3. Add new `Options` `SilencePingLogging` bool that adds `PingPath` to the `ExcludeLoggingPaths` list, in effect silencing logging of requests to `/ping`.
   Default `false` = don't silence logging of requests to `/ping`.

An alternative implementation could be to extend the `loggingHandler struct` with `Options`?
Not sure, open to feedback and happy to revise as preferred.

## Motivation and Context

Resolve issue: #167 
Kubernetes health checking `/ping` endpoint creates unnecessary (for us) log entries.

## How Has This Been Tested?

Kubernetes 1.13 and 1.14 with Google Groups OAUTH.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
