### PR TITLE
HotFix v3.2.0 add azure option azure-domain-hint

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	flagSet.Var(&emailDomains, "email-domain", "authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email")
 	flagSet.Var(&whitelistDomains, "whitelist-domain", "allowed domains for redirection after authentication. Prefix domain with a . to allow subdomains (eg .example.com)")
 	flagSet.String("azure-tenant", "common", "go to a tenant-specific or common (tenant-independent) endpoint.")
+	flagSet.String("azure-domain-hint", "", "specified domain to query.")
 	flagSet.String("github-org", "", "restrict logins to members of this organisation")
 	flagSet.String("github-team", "", "restrict logins to members of this team")
 	flagSet.Var(&googleGroups, "google-group", "restrict logins to members of this google group (may be given multiple times).")

--- a/options.go
+++ b/options.go
@@ -34,6 +34,7 @@ type Options struct {
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file" env:"OAUTH2_PROXY_AUTHENTICATED_EMAILS_FILE"`
 	AzureTenant              string   `flag:"azure-tenant" cfg:"azure_tenant" env:"OAUTH2_PROXY_AZURE_TENANT"`
+	AzureDomainHint          string   `flag:"azure-domain-hint" cfg:"azure_domain_hint" env:"OAUTH2_PROXY_AZURE_DOMAIN_HINT"`
 	EmailDomains             []string `flag:"email-domain" cfg:"email_domains" env:"OAUTH2_PROXY_EMAIL_DOMAINS"`
 	WhitelistDomains         []string `flag:"whitelist-domain" cfg:"whitelist_domains" env:"OAUTH2_PROXY_WHITELIST_DOMAINS"`
 	GitHubOrg                string   `flag:"github-org" cfg:"github_org" env:"OAUTH2_PROXY_GITHUB_ORG"`
@@ -307,7 +308,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	o.provider = providers.New(o.Provider, p)
 	switch p := o.provider.(type) {
 	case *providers.AzureProvider:
-		p.Configure(o.AzureTenant)
+		p.Configure(o.AzureTenant, o.AzureDomainHint)
 	case *providers.GitHubProvider:
 		p.SetOrgTeam(o.GitHubOrg, o.GitHubTeam)
 	case *providers.GoogleProvider:

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -15,6 +15,7 @@ import (
 type AzureProvider struct {
 	*ProviderData
 	Tenant string
+	DomainHint string
 }
 
 // NewAzureProvider initiates a new AzureProvider
@@ -43,7 +44,8 @@ func NewAzureProvider(p *ProviderData) *AzureProvider {
 }
 
 // Configure defaults the AzureProvider configuration options
-func (p *AzureProvider) Configure(tenant string) {
+func (p *AzureProvider) Configure(tenant string, domainhint string) {
+	p.DomainHint = domainhint
 	p.Tenant = tenant
 	if tenant == "" {
 		p.Tenant = "common"
@@ -127,3 +129,23 @@ func (p *AzureProvider) GetEmailAddress(s *SessionState) (string, error) {
 
 	return email, err
 }
+
+// GetLoginURL with typical oauth parameters
+func (p *AzureProvider)  GetLoginURL(redirectURI, state string) string {
+	var a url.URL
+	a = *p.LoginURL
+	params, _ := url.ParseQuery(a.RawQuery)
+	params.Set("redirect_uri", redirectURI)
+	params.Set("approval_prompt", p.ApprovalPrompt)
+    if p.DomainHint != "" {
+        params.Add("domain_hint", p.DomainHint)
+    }
+	params.Add("scope", p.Scope)
+	params.Set("client_id", p.ClientID)
+	params.Set("response_type", "code")
+	params.Add("state", state)
+	a.RawQuery = params.Encode()
+	return a.String()
+}
+
+


### PR DESCRIPTION
Add option domain_hint for azure provider,

domain_hint is optional.    Provides a hint about the tenant or domain
that the user should use to sign in. The value of the domain_hint is a
registered domain for the tenant. If the tenant is federated to an
on-premises directory, AAD redirects to the specified tenant federation
server.

Ref :
https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code

This parameter should be include in the login URL.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
