### PR TITLE
Install gometalinter in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,18 @@ FROM golang:1.12-stretch AS builder
 # Download tools
 RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
 RUN chmod +x $GOPATH/bin/dep
+RUN go get github.com/alecthomas/gometalinter
+RUN gometalinter --install
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
-COPY . .
+COPY Gopkg.lock .
+COPY Gopkg.toml .
 
 # Fetch dependencies
 RUN dep ensure --vendor-only
+
+COPY . .
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.12-stretch AS builder
 # Download tools
 RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
 RUN chmod +x $GOPATH/bin/dep
-RUN go get github.com/alecthomas/gometalinter
-RUN gometalinter --install
+RUN go get github.com/alecthomas/gometalinter && gometalinter --install
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,13 +3,17 @@ FROM golang:1.12-stretch AS builder
 # Download tools
 RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
 RUN chmod +x $GOPATH/bin/dep
+RUN go get github.com/alecthomas/gometalinter && gometalinter --install
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
-COPY . .
+COPY Gopkg.lock .
+COPY Gopkg.toml .
 
 # Fetch dependencies
 RUN dep ensure --vendor-only
+
+COPY . .
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -3,13 +3,17 @@ FROM golang:1.12-stretch AS builder
 # Download tools
 RUN wget -O $GOPATH/bin/dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
 RUN chmod +x $GOPATH/bin/dep
+RUN go get github.com/alecthomas/gometalinter && gometalinter --install
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
-COPY . .
+COPY Gopkg.lock .
+COPY Gopkg.toml .
 
 # Fetch dependencies
 RUN dep ensure --vendor-only
+
+COPY . .
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because


### PR DESCRIPTION
## Description

This improves local development with Docker.

- This installs gometalinter in the container
- This improves layer caching by deferring the `COPY . .` until after `dep ensure`

## Motivation and Context

- A naive checkout of master and a `docker build .` fails, possibly from changes to #176 
- The `COPY . .` directive unnecessarily invalidates the cache before every `docker build`, causing `dep ensure` to always execute.

## How Has This Been Tested?

- `docker build .` now works from a vanilla checkout
- Modifying files other than `Gopkg.lock` and `Gopkg.toml` doesn't trigger cache layer invalidation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
