### PR TITLE
Adds banner flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - [#185](https://github.com/pusher/oauth2_proxy/pull/185) Fix an unsupported protocol scheme error during token validation when using the Azure provider (@jonas)
 - [#141](https://github.com/pusher/oauth2_proxy/pull/141) Check google group membership based on email address (@bchess)
   - Google Group membership is additionally checked via email address, allowing users outside a GSuite domain to be authorized.
+- [#195](https://github.com/pusher/outh2_proxy/pull/195) Add `-banner` flag for overriding the banner line that is displayed (@steakunderscore)
 
 # v3.2.0
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -43,6 +43,7 @@ Usage of oauth2_proxy:
   -email-domain value: authenticate emails with the specified domain (may be given multiple times). Use * to authenticate any email
   -extra-jwt-issuers: if -skip-jwt-bearer-tokens is set, a list of extra JWT issuer=audience pairs (where the issuer URL has a .well-known/openid-configuration or a .well-known/jwks.json)
   -flush-interval: period between flushing response buffers when streaming responses (default "1s")
+  -banner string: custom banner string. Use "-" to disable default banner.
   -footer string: custom footer string. Use "-" to disable default footer.
   -gcp-healthchecks: will enable /liveness_check, /readiness_check, and / (with the proper user-agent) endpoints that will make it work well with GCP App Engine and GKE Ingresses (default false)
   -github-org string: restrict logins to members of this organisation

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func main() {
 	flagSet.String("htpasswd-file", "", "additionally authenticate against a htpasswd file. Entries must be created with \"htpasswd -s\" for SHA encryption or \"htpasswd -B\" for bcrypt encryption")
 	flagSet.Bool("display-htpasswd-form", true, "display username / password login form if an htpasswd file is provided")
 	flagSet.String("custom-templates-dir", "", "path to custom html templates")
+	flagSet.String("banner", "", "custom banner string. Use \"-\" to disable default banner.")
 	flagSet.String("footer", "", "custom footer string. Use \"-\" to disable default footer.")
 	flagSet.String("proxy-prefix", "/oauth2", "the url root path that this proxy should be nested under (e.g. /<oauth2>/sign_in)")
 	flagSet.Bool("proxy-websockets", true, "enables WebSocket proxying")
@@ -148,7 +149,13 @@ func main() {
 	validator := NewValidator(opts.EmailDomains, opts.AuthenticatedEmailsFile)
 	oauthproxy := NewOAuthProxy(opts, validator)
 
-	if len(opts.EmailDomains) != 0 && opts.AuthenticatedEmailsFile == "" {
+	if len(opts.Banner) >= 1 {
+		if opts.Banner == "-" {
+			oauthproxy.SignInMessage = ""
+		} else {
+			oauthproxy.SignInMessage = opts.Banner
+		}
+	} else if len(opts.EmailDomains) != 0 && opts.AuthenticatedEmailsFile == "" {
 		if len(opts.EmailDomains) > 1 {
 			oauthproxy.SignInMessage = fmt.Sprintf("Authenticate using one of the following domains: %v", strings.Join(opts.EmailDomains, ", "))
 		} else if opts.EmailDomains[0] != "*" {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -98,6 +98,7 @@ type OAuthProxy struct {
 	jwtBearerVerifiers  []*oidc.IDTokenVerifier
 	compiledRegex       []*regexp.Regexp
 	templates           *template.Template
+	Banner              string
 	Footer              string
 }
 
@@ -269,6 +270,7 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		PassAuthorization:   opts.PassAuthorization,
 		SkipProviderButton:  opts.SkipProviderButton,
 		templates:           loadTemplates(opts.CustomTemplatesDir),
+		Banner:              opts.Banner,
 		Footer:              opts.Footer,
 	}
 }

--- a/options.go
+++ b/options.go
@@ -51,6 +51,7 @@ type Options struct {
 	HtpasswdFile             string   `flag:"htpasswd-file" cfg:"htpasswd_file" env:"OAUTH2_PROXY_HTPASSWD_FILE"`
 	DisplayHtpasswdForm      bool     `flag:"display-htpasswd-form" cfg:"display_htpasswd_form" env:"OAUTH2_PROXY_DISPLAY_HTPASSWD_FORM"`
 	CustomTemplatesDir       string   `flag:"custom-templates-dir" cfg:"custom_templates_dir" env:"OAUTH2_PROXY_CUSTOM_TEMPLATES_DIR"`
+	Banner                   string   `flag:"banner" cfg:"banner" env:"OAUTH2_PROXY_BANNER"`
 	Footer                   string   `flag:"footer" cfg:"footer" env:"OAUTH2_PROXY_FOOTER"`
 
 	// Embed CookieOptions


### PR DESCRIPTION
## Description

Adds a banner flag to override what's displayed on the main login page.

## Motivation and Context

This is to implement the suggestion in #193

## How Has This Been Tested?

Built docker image after applying patch in #190. Run in Kubernetes to load page and see that both `-banner='-'` and `-banner='My sweet banner'` worked.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
