### PR TITLE
update configuration.md auth_request section

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -313,3 +313,5 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
     end
   }
 ```
+
+You have to substitute *name* with the actual cookie name you configured via --cookie-name parameter. If you don't set a custom cookie name the variable  should be "$upstream_cookie__oauth2_proxy_1" instead of "$upstream_cookie_name_1" and the new cookie-name should be "_oauth2_proxy_1=" instead of "name_1=".


### PR DESCRIPTION
##  Description

The description of the configuration snippet for nginx in configuration.md in the auth_request section could use a hint to replace the generic variable name in this example with the configured cookie name

## Motivation and Context

I wasted some hours trying to get the example provided in #29 and in the documentation working. I didn't know that I have to substitute the cookie name because of my missing knowledge of nginx configuration.

## How Has This Been Tested?

Only a documentation change and works now as described in our system.

## Checklist:

- [x ] My change requires a change to the documentation or CHANGELOG.
- [x ] I have updated the documentation/CHANGELOG accordingly.
- [x ] I have created a feature (non-master) branch for my PR.
