### PR TITLE
Move docker dep commands to earlier in the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ## Changes since v3.2.0
 
+- [#209](https://github.com/pusher/outh2_proxy/pull/209) Improve docker build caching of layers (@dekimsey)
 - [#186](https://github.com/pusher/oauth2_proxy/pull/186) Make config consistent (@JoelSpeed)
 - [#187](https://github.com/pusher/oauth2_proxy/pull/187) Move root packages to pkg folder (@JoelSpeed)
 - [#65](https://github.com/pusher/oauth2_proxy/pull/65) Improvements to authenticate requests with a JWT bearer token in the `Authorization` header via

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,13 @@ RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.s
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
-COPY . .
 
 # Fetch dependencies
+COPY Gopkg.toml Gopkg.lock ./
 RUN dep ensure --vendor-only
+
+# Now pull in our code
+COPY . .
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -7,10 +7,13 @@ RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.s
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
-COPY . .
 
 # Fetch dependencies
+COPY Gopkg.toml Gopkg.lock ./
 RUN dep ensure --vendor-only
+
+# Now pull in our code
+COPY . .
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -7,10 +7,13 @@ RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.s
 
 # Copy sources
 WORKDIR $GOPATH/src/github.com/pusher/oauth2_proxy
-COPY . .
 
 # Fetch dependencies
+COPY Gopkg.toml Gopkg.lock ./
 RUN dep ensure --vendor-only
+
+# Now pull in our code
+COPY . .
 
 # Build binary and make sure there is at least an empty key file.
 #  This is useful for GCP App Engine custom runtime builds, because

--- a/configure
+++ b/configure
@@ -116,9 +116,7 @@ check_go_env() {
 
 cd ${0%/*}
 
-if [ ! -f .env ]; then
-  rm .env
-fi
+rm -fv .env
 
 check_for make
 check_for awk


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This will let Docker cache the results of the vendor dependencies.
Making re-builds during testing faster.

I also changed the logic to just `rm -f` the .env which silences a spurious error message I was encountering.

```
Step 9/15 : RUN ./configure && make build && touch jwt_signing_key.pem
 ---> Running in c77e9d8bca8d
rm: cannot remove '.env': No such file or directory
Checking for make... found
Checking for awk... found
Checking for go... found
```

## Motivation and Context

To test my changes, I'm just running `docker build .` repeatedly. I found the dep ensure command took a long time to do it's work. 

## How Has This Been Tested?

It builds without triggering re-downloading of vendor artifacts.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
