### PR TITLE
Fix tls-cert and tls-key flags.

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,8 +32,8 @@ func main() {
 
 	flagSet.String("http-address", "127.0.0.1:4180", "[http://]<addr>:<port> or unix://<path> to listen on for HTTP clients")
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
-	flagSet.String("tls-cert", "", "path to certificate file")
-	flagSet.String("tls-key", "", "path to private key file")
+	flagSet.String("tls-cert-file", "", "path to certificate file")
+	flagSet.String("tls-key-file", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint or file:// paths for static files. Routing is based on the path")


### PR DESCRIPTION
Without the fix the binary crashes with the error:

```
2019/07/17 10:16:05 ERROR: flag "tls-cert-file" does not exist
panic: ERROR: flag "tls-cert-file" does not exist

goroutine 1 [running]:
log.Panicf(0xa00fe9, 0x1d, 0xc0000e1d08, 0x1, 0x1)
	/usr/local/go/src/log/log.go:340 +0xc0
github.com/pusher/oauth2_proxy/vendor/github.com/mreiferson/go-options.Resolve(0x9498e0, 0xc000168000, 0xc000114660, 0xc000116e10)
	/home/adegano/work/go_projects/src/github.com/pusher/oauth2_proxy/vendor/github.com/mreiferson/go-options/options.go:73 +0xb85
main.main()
	/home/adegano/work/go_projects/src/github.com/pusher/oauth2_proxy/main.go:144 +0x1d73
```

- [X] I have created a feature (non-master) branch for my PR.
