### PR TITLE
Add MAINTAINERS and update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
-# Default owner should be a Pusher cloud-team member unless overridden by later
-# rules in this file
+# Default owner should be a Pusher cloud-team member or another maintainer
+# unless overridden by later rules in this file
 * @pusher/cloud-team
+* @syscll
+* @steakunderscore
 
 # login.gov provider
 # Note:  If @timothy-spencer terms out of his appointment, your best bet

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,3 @@
+Joel Speed <joel.speed@hotmail.co.uk> (@JoelSpeed)
+Dan Bond (@syscll)
+Henry Jenkins <henry@henryjenkins.name> (@steakunderscore)


### PR DESCRIPTION
## Description

This PR adds a MAINTAINERS file listing the current maintainers for the project, this should allow people interacting with the project to know who is maintaining the project

This also adds @syscll and @steakunderscore as CODEOWNERS, which means that once they have approved a PR, it can be merged even without a Pusher approval (which is currently required)

## Motivation and Context

It should be easy to get a review and know who maintains the project

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
