### PR TITLE
Check Google group membership with hasMember and get.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ## Changes since v3.2.0
 
+- [#224](https://github.com/pusher/oauth2_proxy/pull/224) Check Google group membership using hasMember to support nested groups and external users (@jpalpant)
 - [#178](https://github.com/pusher/outh2_proxy/pull/178) Add Silence Ping Logging and Exclude Logging Paths flags (@kskewes)
 - [#209](https://github.com/pusher/outh2_proxy/pull/209) Improve docker build caching of layers (@dekimsey)
 - [#186](https://github.com/pusher/oauth2_proxy/pull/186) Make config consistent (@JoelSpeed)

--- a/providers/google.go
+++ b/providers/google.go
@@ -189,71 +189,35 @@ func getAdminService(adminEmail string, credentialsReader io.Reader) *admin.Serv
 }
 
 func userInGroup(service *admin.Service, groups []string, email string) bool {
-	user, err := fetchUser(service, email)
-	if err != nil {
-		logger.Printf("Warning: unable to fetch user: %v", err)
-		user = nil
-	}
-
 	for _, group := range groups {
-		members, err := fetchGroupMembers(service, group)
+		req := service.Members.HasMember(group, email)
+		r, err := req.Do()
 		if err != nil {
-			if err, ok := err.(*googleapi.Error); ok && err.Code == 404 {
-				logger.Printf("error fetching members for group %s: group does not exist", group)
-			} else {
-				logger.Printf("error fetching group members: %v", err)
-				return false
-			}
-		}
+			err, ok := err.(*googleapi.Error)
+			if ok && err.Code == 404 {
+				logger.Printf("error checking membership in group %s: group does not exist", group)
+			} else if ok && err.Code == 400 {
+				req := service.Members.Get(group, email)
+				r, err := req.Do()
 
-		for _, member := range members {
-			if member.Email == email {
-				return true
-			}
-			if user == nil {
-				continue
-			}
-			switch member.Type {
-			case "CUSTOMER":
-				if member.Id == user.CustomerId {
+				if err != nil {
+					logger.Printf("error using get API to check member %s of google group %s", email, group)
+					continue
+				}
+
+				if r.Status == "ACTIVE" {
 					return true
 				}
-			case "USER":
-				if member.Id == user.Id {
-					return true
-				}
+			} else {
+				logger.Printf("error checking group membership: %v", err)
 			}
+			continue
+		}
+		if r.IsMember {
+			return true
 		}
 	}
 	return false
-}
-
-func fetchUser(service *admin.Service, email string) (*admin.User, error) {
-	user, err := service.Users.Get(email).Do()
-	return user, err
-}
-
-func fetchGroupMembers(service *admin.Service, group string) ([]*admin.Member, error) {
-	members := []*admin.Member{}
-	pageToken := ""
-	for {
-		req := service.Members.List(group)
-		if pageToken != "" {
-			req.PageToken(pageToken)
-		}
-		r, err := req.Do()
-		if err != nil {
-			return nil, err
-		}
-		for _, member := range r.Members {
-			members = append(members, member)
-		}
-		if r.NextPageToken == "" {
-			break
-		}
-		pageToken = r.NextPageToken
-	}
-	return members, nil
 }
 
 // ValidateGroup validates that the provided email exists in the configured Google

--- a/providers/google_test.go
+++ b/providers/google_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	admin "google.golang.org/api/admin/directory/v1"
+	option "google.golang.org/api/option"
 )
 
 func newRedeemServer(body []byte) (*url.URL, *httptest.Server) {
@@ -186,38 +188,40 @@ func TestGoogleProviderGetEmailAddressEmailMissing(t *testing.T) {
 func TestGoogleProviderUserInGroup(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/groups/group@example.com/hasMember/member-in-domain@example.com" {
-			fmt.Fprintln(w, "{\"isMember\": true}")
+			fmt.Fprintln(w, `{"isMember": true}`)
 		} else if r.URL.Path == "/groups/group@example.com/hasMember/non-member-in-domain@example.com" {
-			fmt.Fprintln(w, "{\"isMember\": false}")
+			fmt.Fprintln(w, `{"isMember": false}`)
 		} else if r.URL.Path == "/groups/group@example.com/hasMember/member-out-of-domain@otherexample.com" {
 			http.Error(
 				w,
-				"{\"error\": {\"errors\": [{\"domain\": \"global\",\"reason\": \"invalid\",\"message\": \"Invalid Input: memberKey\"}],\"code\": 400,\"message\": \"Invalid Input: memberKey\"}",
+				`{"error": {"errors": [{"domain": "global","reason": "invalid","message": "Invalid Input: memberKey"}],"code": 400,"message": "Invalid Input: memberKey"}}`,
 				http.StatusBadRequest,
 			)
 		} else if r.URL.Path == "/groups/group@example.com/hasMember/non-member-out-of-domain@otherexample.com" {
 			http.Error(
 				w,
-				"{\"error\": {\"errors\": [{\"domain\": \"global\",\"reason\": \"invalid\",\"message\": \"Invalid Input: memberKey\"}],\"code\": 400,\"message\": \"Invalid Input: memberKey\"}",
+				`{"error": {"errors": [{"domain": "global","reason": "invalid","message": "Invalid Input: memberKey"}],"code": 400,"message": "Invalid Input: memberKey"}}`,
 				http.StatusBadRequest,
 			)
 		} else if r.URL.Path == "/groups/group@example.com/members/non-member-out-of-domain@otherexample.com" {
 			// note that the client currently doesn't care what this response text or code is - any error here results in failure to match the group
 			http.Error(
 				w,
-				"{\"error\": {\"errors\": [{\"domain\": \"global\",\"reason\": \"notFound\",\"message\": \"Resource Not Found: memberKey\"}],\"code\": 404,\"message\": \"Resource Not Found: memberKey\"}",
+				`{"error": {"errors": [{"domain": "global","reason": "notFound","message": "Resource Not Found: memberKey"}],"code": 404,"message": "Resource Not Found: memberKey"}}`,
 				http.StatusNotFound,
 			)
 		} else if r.URL.Path == "/groups/group@example.com/members/member-out-of-domain@otherexample.com" {
 			fmt.Fprintln(w,
-				"{\"kind\": \"admin#directory#member\",\"etag\":\"12345\",\"id\":\"1234567890\",\"email\": \"member-out-of-domain@otherexample.com\",\"role\": \"MEMBER\",\"type\": \"USER\",\"status\": \"ACTIVE\",\"delivery_settings\": \"ALL_MAIL\"}",
+				`{"kind": "admin#directory#member","etag":"12345","id":"1234567890","email": "member-out-of-domain@otherexample.com","role": "MEMBER","type": "USER","status": "ACTIVE","delivery_settings": "ALL_MAIL"}}`,
 			)
 		}
 	}))
 	defer ts.Close()
 
 	client := ts.Client()
-	service, err := admin.New(client)
+	ctx := context.Background()
+
+	service, err := admin.NewService(ctx, option.WithHTTPClient(client))
 	service.BasePath = ts.URL
 	assert.Equal(t, nil, err)
 


### PR DESCRIPTION
## Description

This PR is an enhancement built on https://github.com/pusher/oauth2_proxy/pull/160. That PR reduces the number of calls to the Google Admin API and simplifies the code by using the hasMember method. It also supports checking membership in nested groups.

However, the above message doesn't handle members who are not a part of the domain. The hasMember API returns a 400 for that case. As a fallback, when the API returns a 400, this change will try using the `get` API which works as expected for members who aren't a part of the domain. Supporting members who belong to the Google group but aren't part of the domain is a requested feature from https://github.com/pusher/oauth2_proxy/issues/95.

https://developers.google.com/admin-sdk/directory/v1/reference/members/get

Note that nested members who are not a part of the domain will not be correctly detected with this change.

## Motivation and Context

This PR continues the work of https://github.com/pusher/oauth2_proxy/pull/160 to improve the Google auth support when using a Google group as a filter. It reduces the complexity of the code, number of API calls, and handles members of nested groups. Additionally it maintains the functionality of checking for group members who do not have the same domain as the target user.

## How Has This Been Tested?

I have tested this manually against my own Google groups by running `oauth2_proxy` using the arguments `-email-domain=* -google-group=$MYGROUP -provider=google -google-admin-email=$ADMIN_EMAIL -google-service-account-json=/path/to/serviceaccount.json`. Within that context I have checked that authorization works as expected for:

* (allowed) a member of the group with the group domain 
* (allowed) a member of the group with an external domain
* (disallowed) nonmember of the group with the group domain
* (disallowed) nonmember of the group with an external domain
* (allowed) member of a subgroup where subgroup and user have the group domain

I have not tested other configurations yet, such as Google authentication without the groups filter. However I don't believe I've touched those parts of the code. I have not tested multiple-groups.

I modified the unit tests for the Google provider. Since the function makes different requests, I have written new tests and modified the dummy server to have responses for each request that will be made.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
