### PR TITLE
Fix CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,6 @@
 # Default owner should be a Pusher cloud-team member or another maintainer
 # unless overridden by later rules in this file
-* @pusher/cloud-team
-* @syscll
-* @steakunderscore
+* @pusher/cloud-team @syscll @steakunderscore
 
 # login.gov provider
 # Note:  If @timothy-spencer terms out of his appointment, your best bet


### PR DESCRIPTION
## Description

Fix the Codeowners so that all maintainers are requested for reviews

## Motivation and Context

I assumed separate lines would be ok, but that doesn't seemed to have work and the [docs](https://help.github.com/en/articles/about-code-owners) suggest it should be one line

Currently it thinks only the last entry is the owner.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
