### PR TITLE
Remove dep from Travis CI & pre-install modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 install:
   # Fetch dependencies
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
+  - GO111MODULE=on go mod download
 script:
   - ./configure && make test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ go:
   - 1.12.x
 install:
   # Fetch dependencies
-  - wget -O dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
-  - chmod +x dep
-  - mv dep $GOPATH/bin/dep
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
 script:
   - ./configure && make test


### PR DESCRIPTION
## Description

Was missed from previous switch to go modules. Also to stop linting from timing out, install modules in the install setep.

## Motivation and Context

Dep isn't used any more, so just being tidy and removing it.

## How Has This Been Tested?

Testing by getting Travis to build it

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
