### PR TITLE
Fix links in docs

### DIFF
--- a/docs/0_index.md
+++ b/docs/0_index.md
@@ -12,7 +12,7 @@ to validate accounts by email, domain or group.
 
 **Note:** This repository was forked from [bitly/OAuth2_Proxy](https://github.com/bitly/oauth2_proxy) on 27/11/2018.
 Versions v3.0.0 and up are from this fork and will have diverged from any changes in the original fork.
-A list of changes can be seen in the [CHANGELOG](CHANGELOG.md).
+A list of changes can be seen in the [CHANGELOG]({{ site.gitweb }}/CHANGELOG.md).
 
 [![Build Status](https://secure.travis-ci.org/pusher/oauth2_proxy.svg?branch=master)](http://travis-ci.org/pusher/oauth2_proxy)
 

--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -103,7 +103,7 @@ If you are using GitHub enterprise, make sure you set the following to the appro
 
 ### GitLab Auth Provider
 
-Whether you are using GitLab.com or self-hosting GitLab, follow [these steps to add an application](http://doc.gitlab.com/ce/integration/oauth_provider.html). Make sure to enable at least the `openid`, `profile` and `email` scopes.
+Whether you are using GitLab.com or self-hosting GitLab, follow [these steps to add an application](https://docs.gitlab.com/ce/integration/oauth_provider.html). Make sure to enable at least the `openid`, `profile` and `email` scopes.
 
 Restricting by group membership is possible with the following option:
 
@@ -126,7 +126,7 @@ For LinkedIn, the registration steps are:
 
 ### Microsoft Azure AD Provider
 
-For adding an application to the Microsoft Azure AD follow [these steps to add an application](https://azure.microsoft.com/en-us/documentation/articles/active-directory-integrating-applications/).
+For adding an application to the Microsoft Azure AD follow [these steps to add an application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app).
 
 Take note of your `TenantId` if applicable for your situation. The `TenantId` can be used to override the default `common` authorization server with a tenant specific server.
 
@@ -277,7 +277,7 @@ To authorize by email domain use `--email-domain=yourcompany.com`. To authorize 
 
 ## Adding a new Provider
 
-Follow the examples in the [`providers` package](providers/) to define a new
+Follow the examples in the [`providers` package]({{ site.gitweb }}/providers/) to define a new
 `Provider` instance. Add a new `case` to
-[`providers.New()`](providers/providers.go) to allow `oauth2_proxy` to use the
+[`providers.New()`]({{ site.gitweb }}/providers/providers.go) to allow `oauth2_proxy` to use the
 new `Provider`.

--- a/docs/6_request_signatures.md
+++ b/docs/6_request_signatures.md
@@ -11,7 +11,7 @@ If `signature_key` is defined, proxied requests will be signed with the
 `GAP-Signature` header, which is a [Hash-based Message Authentication Code
 (HMAC)](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code)
 of selected request information and the request body [see `SIGNATURE_HEADERS`
-in `oauthproxy.go`](./oauthproxy.go).
+in `oauthproxy.go`]({{ site.gitweb }}/oauthproxy.go).
 
 `signature_key` must be of the form `algorithm:secretkey`, (ie: `signature_key = "sha1:secret0"`)
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,6 +18,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   OAuth2_Proxy documentation site
 baseurl: "/oauth2_proxy" # the subpath of your site, e.g. /blog
 url: "https://pusher.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+gitweb: "https://github.com/pusher/oauth2_proxy/blob/master"
 
 # Build settings
 markdown: kramdown

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -14,7 +14,7 @@ To generate a strong cookie secret use `python -c 'import os,base64; print base6
 
 ### Config File
 
-An example [oauth2_proxy.cfg](https://github.com/pusher/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) config file is in the contrib directory. It can be used by specifying `-config=/etc/oauth2_proxy.cfg`
+An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example) config file is in the contrib directory. It can be used by specifying `-config=/etc/oauth2_proxy.cfg`
 
 ### Command Line Options
 

--- a/docs/configuration/sessions.md
+++ b/docs/configuration/sessions.md
@@ -15,8 +15,8 @@ The OAuth2 Proxy uses a Cookie to track user sessions and will store the session
 data in one of the available session storage backends.
 
 At present the available backends are (as passed to `--session-store-type`):
-- [cookie](cookie-storage) (default)
-- [redis](redis-storage)
+- [cookie](#cookie-storage) (default)
+- [redis](#redis-storage)
 
 ### Cookie Storage
 


### PR DESCRIPTION

## Description

- Fixed a bunch of references to the repo, which were 404ing
- Fixed a couple of things that 301/302ed
- Fixed some in page references

## Motivation and Context

Well... they were broken ;)

## How Has This Been Tested?

Poked a couple of the links running `make serve` locally.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
