### PR TITLE
More fully support X-Auth-Request-Redirect header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 # v4.0.0
 
+- [#248](https://github.com/pusher/oauth2_proxy/pull/248) Fix issue with X-Auth-Request-Redirect header being ignored
+
 ## Release Highlights
 - Documentation is now on a [microsite](https://pusher.github.io/oauth2_proxy/)
 - Health check logging can now be disabled for quieter logs

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -247,6 +247,8 @@ server {
     proxy_set_header X-Real-IP               $remote_addr;
     proxy_set_header X-Scheme                $scheme;
     proxy_set_header X-Auth-Request-Redirect $request_uri;
+    # or, if you are handling multiple domains:
+    # proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
   }
   location = /oauth2/auth {
     proxy_pass       http://127.0.0.1:4180;

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -480,7 +480,10 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 		return
 	}
 
-	redirect = req.Form.Get("rd")
+	redirect = req.Header.Get("X-Auth-Request-Redirect")
+	if req.Form.Get("rd") != "" {
+		redirect = req.Form.Get("rd")
+	}
 	if !p.IsValidRedirect(redirect) {
 		redirect = req.URL.Path
 		if strings.HasPrefix(redirect, p.ProxyPrefix) {


### PR DESCRIPTION
Docs showed that the X-Auth-Request-Redirect header can specify a redirect URI, but only the rd POST parameter was being honored

This fixes that.

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
