### PR TITLE
add empty value checking for Bitbucket provider's setTeam/setRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#275](https://github.com/pusher/oauth2_proxy/pull/275) docker: build from debian buster (@syscll)
 - [#258](https://github.com/pusher/oauth2_proxy/pull/258) Add IDToken for Azure provider
   - This PR adds the IDToken into the session for the Azure provider allowing requests to a backend to be identified as a specific user. As a consequence, if you are using a cookie to store the session the cookie will now exceed the 4kb size limit and be split into multiple cookies. This can cause problems when using nginx as a proxy, resulting in no cookie being passed at all. Either increase the proxy_buffer_size in nginx or implement the redis session storage (see https://pusher.github.io/oauth2_proxy/configuration#redis-storage)
+- [#267](https://github.com/pusher/oauth2_proxy/pull/267) Removed unnecessary OAuth2 scopes used in Bitbucket authentication.
 
 # v4.0.0
 

--- a/providers/bitbucket.go
+++ b/providers/bitbucket.go
@@ -50,7 +50,7 @@ func NewBitbucketProvider(p *ProviderData) *BitbucketProvider {
 // SetTeam defines the Bitbucket team the user must be part of
 func (p *BitbucketProvider) SetTeam(team string) {
 	p.Team = team
-	if !strings.Contains(p.Scope, "team") {
+	if team != "" && !strings.Contains(p.Scope, "team") {
 		p.Scope += " team"
 	}
 }
@@ -58,7 +58,7 @@ func (p *BitbucketProvider) SetTeam(team string) {
 // SetRepository defines the repository the user must have access to
 func (p *BitbucketProvider) SetRepository(repository string) {
 	p.Repository = repository
-	if !strings.Contains(p.Scope, "repository") {
+	if repository != "" && !strings.Contains(p.Scope, "repository") {
 		p.Scope += " repository"
 	}
 }

--- a/providers/bitbucket_test.go
+++ b/providers/bitbucket_test.go
@@ -22,13 +22,8 @@ func testBitbucketProvider(hostname, team string, repository string) *BitbucketP
 			ValidateURL:  &url.URL{},
 			Scope:        ""})
 
-	if team != "" {
-		p.SetTeam(team)
-	}
-
-	if repository != "" {
-		p.SetRepository(repository)
-	}
+	p.SetTeam(team)
+	p.SetRepository(repository)
 
 	if hostname != "" {
 		updateURL(p.Data().LoginURL, hostname)


### PR DESCRIPTION
## Description

Resolves #261 

Just adding empty string value checking, like Github provider.

## Motivation and Context

I want to use Bitbucket, without repository scope.

## How Has This Been Tested?

Only with providers/options_test.go changes, the test fails as expected:

```
--- FAIL: TestBitbucketProviderDefaults (0.00s)
    bitbucket_test.go:68: 
        	Error Trace:	bitbucket_test.go:68
        	Error:      	Not equal: 
        	            	expected: "email"
        	            	actual  : "email team repository"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-email
        	            	+email team repository
        	Test:       	TestBitbucketProviderDefaults
--- FAIL: TestBitbucketProviderScopeAdjustForTeam (0.00s)
    bitbucket_test.go:74: 
        	Error Trace:	bitbucket_test.go:74
        	Error:      	Not equal: 
        	            	expected: "email team"
        	            	actual  : "email team repository"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-email team
        	            	+email team repository
        	Test:       	TestBitbucketProviderScopeAdjustForTeam
--- FAIL: TestBitbucketProviderScopeAdjustForRepository (0.00s)
    bitbucket_test.go:80: 
        	Error Trace:	bitbucket_test.go:80
        	Error:      	Not equal: 
        	            	expected: "email repository"
        	            	actual  : "email team repository"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-email repository
        	            	+email team repository
        	Test:       	TestBitbucketProviderScopeAdjustForRepository
```

With also providers/options.go change, the test passes.


Also, the built binary works as expected. I use it in my personal project, and the authorize page is shown as below (requires only email, no repository, no team):
<img width="668" alt="貼り付けた画像_2019_09_08_2_43" src="https://user-images.githubusercontent.com/11763113/64478364-8d99ed00-d1e2-11e9-8a4e-f7f7fffcc284.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
  - just a bugfix, not required.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
