### PR TITLE
Escape original request URI in sample kubernetes ingress configuration

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -310,7 +310,7 @@ If you use ingress-nginx in Kubernetes (which includes the Lua module), you also
 
 ```yaml
 nginx.ingress.kubernetes.io/auth-response-headers: Authorization
-nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$request_uri
+nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
 nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
 nginx.ingress.kubernetes.io/configuration-snippet: |
   auth_request_set $name_upstream_1 $upstream_cookie_name_1;


### PR DESCRIPTION
This PR updates the sample configuration for using oauth2_proxy with kubernetes ingress, to resolve an issue with the signin page potentially dropping query parameters from the original request.

The current sample configuration for kubernetes ingress demonstrates
using the `auth-signin` annotation to redirect a user to oauth2_proxy's
signin page. It constructs the link to do so by directly concatenating
`$request_uri` as the `rd` parameter, so the sign-in page knows where to
send the user after signin is complete.

However, this does not work correctly if the original request URI
contains multiple query parameters separated by an ampersand, as that
ampersand is interpereted as separating query parameters of the
`/oauth2/start` URI. For example:

If the user requests a URL:
  `https://example.com/foo?q1=v1&q2=v2`
they may be redirected to the signin url
  `https://example.com/oauth2/start?rd=https://example.com/foo?q1=v1&q2=v2`
and after completing signin, oauth2_proxy will redirect them to
  h`ttps://example.com/foo?q1=v1`

nginx-ingress added an `$escaped_request_uri `variable about a year ago,
to help resolve this kind of issue
(https://github.com/kubernetes/ingress-nginx/pull/2811)

## How Has This Been Tested?

We have an application, deployed on kubernetes, with an ingress, that takes multiple query parameters. I confirmed that the flow of 
* being in a logged-out state
* attempting to access an endpoint with multiple query parameters
* being redirected to signin
* completing signin
* being redirected to my original endpoint
resulted in the original endpoint receiving only one query parameter.

After updating the configuration of our ingress with `$escaped_request_uri`, and re-performing this test, I confirmed that query parameters were preserved.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
