### PR TITLE
Fix permalinks for configuration and sessions

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Configuration
-permalink: /docs/configuration
+permalink: /configuration
 has_children: true
 nav_order: 3
 ---

--- a/docs/configuration/sessions.md
+++ b/docs/configuration/sessions.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Sessions
-permalink: /configuration
+permalink: /configuration/sessions
 parent: Configuration
 nav_order: 3
 ---
@@ -62,6 +62,6 @@ disclosure.
 When using the redis store, specify `--session-store-type=redis` as well as the Redis connection URL, via
 `--redis-connection-url=redis://host[:port][/db-number]`.
 
-You may also configure the store for Redis Sentinel. In this case, you will want to use the 
-`--redis-use-sentinel=true` flag, as well as configure the flags `--redis-sentinel-master-name` 
+You may also configure the store for Redis Sentinel. In this case, you will want to use the
+`--redis-use-sentinel=true` flag, as well as configure the flags `--redis-sentinel-master-name`
 and `--redis-sentinel-connection-urls` appropriately.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This alters the permalinks for a couple of pages to be consistent with other permalinks

## Motivation and Context

I noticed that the sessions permalink was `/configuration` which struck me as a bit odd

## How Has This Been Tested?

Ran locally using `bundle exec jekyll serve` and it seems to work

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
