### PR TITLE
docker: build from debian buster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#227](https://github.com/pusher/oauth2_proxy/pull/227) Add Keycloak provider (@Ofinka)
 - [#271](https://github.com/pusher/oauth2_proxy/pull/271) Support Go 1.13 (@dio)
+- [#275](https://github.com/pusher/oauth2_proxy/pull/275) docker: build from debian buster (@syscll)
 
 # v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Changes since v4.0.0
 
 - [#227](https://github.com/pusher/oauth2_proxy/pull/227) Add Keycloak provider (@Ofinka)
-- [#271](https://github.com/pusher/oauth2_proxy/pull/271) Support Go 1.13 (@dio)
+- [#273](https://github.com/pusher/oauth2_proxy/pull/273) Support Go 1.13 (@dio)
 - [#275](https://github.com/pusher/oauth2_proxy/pull/275) docker: build from debian buster (@syscll)
 
 # v4.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch AS builder
+FROM golang:1.13-buster AS builder
 
 # Download tools
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch AS builder
+FROM golang:1.13-buster AS builder
 
 # Download tools
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1

--- a/Dockerfile.armv6
+++ b/Dockerfile.armv6
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch AS builder
+FROM golang:1.13-buster AS builder
 
 # Download tools
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As Debian Stretch is now classed as "oldstable", we should switch to using Buster which is the "current stable release".

https://www.debian.org/releases/

## Motivation and Context

> Debian 9 has been superseded by Debian 10.0 ("buster"). 

https://www.debian.org/releases/stretch/

## How Has This Been Tested?

CI has successfully build all relevant binaries on the new `golang:1.13-buster` image.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
