### PR TITLE
Allow to change provider's name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [#248](https://github.com/pusher/oauth2_proxy/pull/248) Fix issue with X-Auth-Request-Redirect header being ignored (@webnard)
 - [#314](https://github.com/pusher/oauth2_proxy/pull/314) Add redirect capability to sign_out (@costelmoraru)
 - [#265](https://github.com/pusher/oauth2_proxy/pull/265) Add upstream with static response (@cgroschupp)
-- [#296](https://github.com/pusher/oauth2_proxy/pull/296) Allow to override provider's name for sign-in page
+- [#296](https://github.com/pusher/oauth2_proxy/pull/296) Allow to override provider's name for sign-in page (@ffdybuster)
 
 # v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#248](https://github.com/pusher/oauth2_proxy/pull/248) Fix issue with X-Auth-Request-Redirect header being ignored (@webnard)
 - [#314](https://github.com/pusher/oauth2_proxy/pull/314) Add redirect capability to sign_out (@costelmoraru)
 - [#265](https://github.com/pusher/oauth2_proxy/pull/265) Add upstream with static response (@cgroschupp)
+- [#296](https://github.com/pusher/oauth2_proxy/pull/296) Allow to override provider's name for sign-in page
 
 # v4.0.0
 

--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -156,7 +156,7 @@ OpenID Connect is a spec for OAUTH 2.0 + identity that is implemented by many ma
 3.  Login with the fixture use in the dex guide and run the oauth2_proxy with the following args:
 
     -provider oidc
-    -provider-name "My OIDC Provider"
+    -provider-display-name "My OIDC Provider"
     -client-id oauth2_proxy
     -client-secret proxy
     -redirect-url http://127.0.0.1:4180/oauth2/callback

--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -156,6 +156,7 @@ OpenID Connect is a spec for OAUTH 2.0 + identity that is implemented by many ma
 3.  Login with the fixture use in the dex guide and run the oauth2_proxy with the following args:
 
     -provider oidc
+    -provider-name "My OIDC Provider"
     -client-id oauth2_proxy
     -client-secret proxy
     -redirect-url http://127.0.0.1:4180/oauth2/callback

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -76,7 +76,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-pass-user-headers` | bool | pass X-Forwarded-User and X-Forwarded-Email information to upstream | true |
 | `-profile-url` | string | Profile access endpoint | |
 | `-provider` | string | OAuth provider | google |
-| `-provider-name` | string | Override the provider's name with the given string; used for the sign-in page | (depends on provider) |
+| `-provider-display-name` | string | Override the provider's name with the given string; used for the sign-in page | (depends on provider) |
 | `-ping-path` | string | the ping endpoint that can be used for basic health checks | `"/ping"` |
 | `-proxy-prefix` | string | the url root path that this proxy should be nested under (e.g. /`<oauth2>/sign_in`) | `"/oauth2"` |
 | `-proxy-websockets` | bool | enables WebSocket proxying | true |

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -76,6 +76,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-pass-user-headers` | bool | pass X-Forwarded-User and X-Forwarded-Email information to upstream | true |
 | `-profile-url` | string | Profile access endpoint | |
 | `-provider` | string | OAuth provider | google |
+| `-provider-name` | string | Override the provider's name with the given string; used for the sign-in page | (depends on provider) |
 | `-ping-path` | string | the ping endpoint that can be used for basic health checks | `"/ping"` |
 | `-proxy-prefix` | string | the url root path that this proxy should be nested under (e.g. /`<oauth2>/sign_in`) | `"/oauth2"` |
 | `-proxy-websockets` | bool | enables WebSocket proxying | true |

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func main() {
 	flagSet.String("auth-logging-format", logger.DefaultAuthLoggingFormat, "Template for authentication log lines")
 
 	flagSet.String("provider", "google", "OAuth provider")
+	flagSet.String("provider-display-name", "", "Provider display name")
 	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
 	flagSet.Bool("insecure-oidc-allow-unverified-email", false, "Don't fail if an email address in an id_token is not verified")
 	flagSet.Bool("skip-oidc-discovery", false, "Skip OIDC discovery and use manually supplied Endpoints")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -79,31 +79,32 @@ type OAuthProxy struct {
 	AuthOnlyPath      string
 	UserInfoPath      string
 
-	redirectURL         *url.URL // the url to receive requests at
-	whitelistDomains    []string
-	provider            providers.Provider
-	sessionStore        sessionsapi.SessionStore
-	ProxyPrefix         string
-	SignInMessage       string
-	HtpasswdFile        *HtpasswdFile
-	DisplayHtpasswdForm bool
-	serveMux            http.Handler
-	SetXAuthRequest     bool
-	PassBasicAuth       bool
-	SkipProviderButton  bool
-	PassUserHeaders     bool
-	BasicAuthPassword   string
-	PassAccessToken     bool
-	SetAuthorization    bool
-	PassAuthorization   bool
-	skipAuthRegex       []string
-	skipAuthPreflight   bool
-	skipJwtBearerTokens bool
-	jwtBearerVerifiers  []*oidc.IDTokenVerifier
-	compiledRegex       []*regexp.Regexp
-	templates           *template.Template
-	Banner              string
-	Footer              string
+	redirectURL          *url.URL // the url to receive requests at
+	whitelistDomains     []string
+	provider             providers.Provider
+	providerNameOverride string
+	sessionStore         sessionsapi.SessionStore
+	ProxyPrefix          string
+	SignInMessage        string
+	HtpasswdFile         *HtpasswdFile
+	DisplayHtpasswdForm  bool
+	serveMux             http.Handler
+	SetXAuthRequest      bool
+	PassBasicAuth        bool
+	SkipProviderButton   bool
+	PassUserHeaders      bool
+	BasicAuthPassword    string
+	PassAccessToken      bool
+	SetAuthorization     bool
+	PassAuthorization    bool
+	skipAuthRegex        []string
+	skipAuthPreflight    bool
+	skipJwtBearerTokens  bool
+	jwtBearerVerifiers   []*oidc.IDTokenVerifier
+	compiledRegex        []*regexp.Regexp
+	templates            *template.Template
+	Banner               string
+	Footer               string
 }
 
 // UpstreamProxy represents an upstream server to proxy to
@@ -282,28 +283,29 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 		UserInfoPath:      fmt.Sprintf("%s/userinfo", opts.ProxyPrefix),
 
-		ProxyPrefix:         opts.ProxyPrefix,
-		provider:            opts.provider,
-		sessionStore:        opts.sessionStore,
-		serveMux:            serveMux,
-		redirectURL:         redirectURL,
-		whitelistDomains:    opts.WhitelistDomains,
-		skipAuthRegex:       opts.SkipAuthRegex,
-		skipAuthPreflight:   opts.SkipAuthPreflight,
-		skipJwtBearerTokens: opts.SkipJwtBearerTokens,
-		jwtBearerVerifiers:  opts.jwtBearerVerifiers,
-		compiledRegex:       opts.CompiledRegex,
-		SetXAuthRequest:     opts.SetXAuthRequest,
-		PassBasicAuth:       opts.PassBasicAuth,
-		PassUserHeaders:     opts.PassUserHeaders,
-		BasicAuthPassword:   opts.BasicAuthPassword,
-		PassAccessToken:     opts.PassAccessToken,
-		SetAuthorization:    opts.SetAuthorization,
-		PassAuthorization:   opts.PassAuthorization,
-		SkipProviderButton:  opts.SkipProviderButton,
-		templates:           loadTemplates(opts.CustomTemplatesDir),
-		Banner:              opts.Banner,
-		Footer:              opts.Footer,
+		ProxyPrefix:          opts.ProxyPrefix,
+		provider:             opts.provider,
+		providerNameOverride: opts.ProviderName,
+		sessionStore:         opts.sessionStore,
+		serveMux:             serveMux,
+		redirectURL:          redirectURL,
+		whitelistDomains:     opts.WhitelistDomains,
+		skipAuthRegex:        opts.SkipAuthRegex,
+		skipAuthPreflight:    opts.SkipAuthPreflight,
+		skipJwtBearerTokens:  opts.SkipJwtBearerTokens,
+		jwtBearerVerifiers:   opts.jwtBearerVerifiers,
+		compiledRegex:        opts.CompiledRegex,
+		SetXAuthRequest:      opts.SetXAuthRequest,
+		PassBasicAuth:        opts.PassBasicAuth,
+		PassUserHeaders:      opts.PassUserHeaders,
+		BasicAuthPassword:    opts.BasicAuthPassword,
+		PassAccessToken:      opts.PassAccessToken,
+		SetAuthorization:     opts.SetAuthorization,
+		PassAuthorization:    opts.PassAuthorization,
+		SkipProviderButton:   opts.SkipProviderButton,
+		templates:            loadTemplates(opts.CustomTemplatesDir),
+		Banner:               opts.Banner,
+		Footer:               opts.Footer,
 	}
 }
 
@@ -464,6 +466,9 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 		Version:       VERSION,
 		ProxyPrefix:   p.ProxyPrefix,
 		Footer:        template.HTML(p.Footer),
+	}
+	if (p.providerNameOverride != "") {
+		t.ProviderName = p.providerNameOverride
 	}
 	p.templates.ExecuteTemplate(rw, "sign_in.html", t)
 }

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -467,7 +467,7 @@ func (p *OAuthProxy) SignInPage(rw http.ResponseWriter, req *http.Request, code 
 		ProxyPrefix:   p.ProxyPrefix,
 		Footer:        template.HTML(p.Footer),
 	}
-	if (p.providerNameOverride != "") {
+	if p.providerNameOverride != "" {
 		t.ProviderName = p.providerNameOverride
 	}
 	p.templates.ExecuteTemplate(rw, "sign_in.html", t)

--- a/options.go
+++ b/options.go
@@ -87,7 +87,7 @@ type Options struct {
 	// These options allow for other providers besides Google, with
 	// potential overrides.
 	Provider                         string `flag:"provider" cfg:"provider" env:"OAUTH2_PROXY_PROVIDER"`
-	ProviderName                     string `flag:"provider-name" cfg:"provider_name" env:"OAUTH2_PROXY_PROVIDER_NAME"`
+	ProviderName                     string `flag:"provider-display-name" cfg:"provider_display_name" env:"OAUTH2_PROXY_PROVIDER_DISPLAY_NAME"`
 	OIDCIssuerURL                    string `flag:"oidc-issuer-url" cfg:"oidc_issuer_url" env:"OAUTH2_PROXY_OIDC_ISSUER_URL"`
 	InsecureOIDCAllowUnverifiedEmail bool   `flag:"insecure-oidc-allow-unverified-email" cfg:"insecure_oidc_allow_unverified_email" env:"OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL"`
 	SkipOIDCDiscovery                bool   `flag:"skip-oidc-discovery" cfg:"skip_oidc_discovery" env:"OAUTH2_PROXY_SKIP_OIDC_DISCOVERY"`

--- a/options.go
+++ b/options.go
@@ -87,6 +87,7 @@ type Options struct {
 	// These options allow for other providers besides Google, with
 	// potential overrides.
 	Provider                         string `flag:"provider" cfg:"provider" env:"OAUTH2_PROXY_PROVIDER"`
+	ProviderName                     string `flag:"provider-name" cfg:"provider_name" env:"OAUTH2_PROXY_PROVIDER_NAME"`
 	OIDCIssuerURL                    string `flag:"oidc-issuer-url" cfg:"oidc_issuer_url" env:"OAUTH2_PROXY_OIDC_ISSUER_URL"`
 	InsecureOIDCAllowUnverifiedEmail bool   `flag:"insecure-oidc-allow-unverified-email" cfg:"insecure_oidc_allow_unverified_email" env:"OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL"`
 	SkipOIDCDiscovery                bool   `flag:"skip-oidc-discovery" cfg:"skip_oidc_discovery" env:"OAUTH2_PROXY_SKIP_OIDC_DISCOVERY"`


### PR DESCRIPTION
## Description

Allows to override the provider's name for the sign-in page.

## Motivation and Context

It would be nice to be able to adjust the provider's name. This is mostly relevant for the OpenID Connect provider: the sign-in page could then be changed from `Sign in with OpenID Connect` to `Sign in with ACME Inc. Login`.

Fixes #295.

## How Has This Been Tested?

Not yet tested.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
