### PR TITLE
Rewrite dist script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#258](https://github.com/pusher/oauth2_proxy/pull/258) Add IDToken for Azure provider
   - This PR adds the IDToken into the session for the Azure provider allowing requests to a backend to be identified as a specific user. As a consequence, if you are using a cookie to store the session the cookie will now exceed the 4kb size limit and be split into multiple cookies. This can cause problems when using nginx as a proxy, resulting in no cookie being passed at all. Either increase the proxy_buffer_size in nginx or implement the redis session storage (see https://pusher.github.io/oauth2_proxy/configuration#redis-storage)
 - [#286](https://github.com/pusher/oauth2_proxy/pull/286) Requests.go updated with useful error messages (@biotom)
+- [#302](https://github.com/pusher/oauth2_proxy/pull/302) Rewrite dist script (@syscll)
 
 # v4.0.0
 

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ test: lint
 
 .PHONY: release
 release: lint test
-	BINARY=$(BINARY) VERSION=${VERSION} ./dist.sh
+	BINARY=${BINARY} VERSION=${VERSION} ./dist.sh

--- a/Makefile
+++ b/Makefile
@@ -61,29 +61,4 @@ test: lint
 
 .PHONY: release
 release: lint test
-	mkdir release
-	mkdir release/$(BINARY)-$(VERSION).darwin-amd64.$(GO_VERSION)
-	mkdir release/$(BINARY)-$(VERSION).linux-amd64.$(GO_VERSION)
-	mkdir release/$(BINARY)-$(VERSION).linux-arm64.$(GO_VERSION)
-	mkdir release/$(BINARY)-$(VERSION).linux-armv6.$(GO_VERSION)
-	mkdir release/$(BINARY)-$(VERSION).windows-amd64.$(GO_VERSION)
-	GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" \
-		-o release/$(BINARY)-$(VERSION).darwin-amd64.$(GO_VERSION)/$(BINARY) github.com/pusher/oauth2_proxy
-	GO111MODULE=on GOOS=linux GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" \
-		-o release/$(BINARY)-$(VERSION).linux-amd64.$(GO_VERSION)/$(BINARY) github.com/pusher/oauth2_proxy
-	GO111MODULE=on GOOS=linux GOARCH=arm64 go build -ldflags="-X main.VERSION=${VERSION}" \
-		-o release/$(BINARY)-$(VERSION).linux-arm64.$(GO_VERSION)/$(BINARY) github.com/pusher/oauth2_proxy
-	GO111MODULE=on GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-X main.VERSION=${VERSION}" \
-		-o release/$(BINARY)-$(VERSION).linux-armv6.$(GO_VERSION)/$(BINARY) github.com/pusher/oauth2_proxy
-	GO111MODULE=on GOOS=windows GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" \
-		-o release/$(BINARY)-$(VERSION).windows-amd64.$(GO_VERSION)/$(BINARY) github.com/pusher/oauth2_proxy
-	shasum -a 256 release/$(BINARY)-$(VERSION).darwin-amd64.$(GO_VERSION)/$(BINARY) > release/$(BINARY)-$(VERSION).darwin-amd64-sha256sum.txt
-	shasum -a 256 release/$(BINARY)-$(VERSION).linux-amd64.$(GO_VERSION)/$(BINARY) > release/$(BINARY)-$(VERSION).linux-amd64-sha256sum.txt
-	shasum -a 256 release/$(BINARY)-$(VERSION).linux-arm64.$(GO_VERSION)/$(BINARY) > release/$(BINARY)-$(VERSION).linux-arm64-sha256sum.txt
-	shasum -a 256 release/$(BINARY)-$(VERSION).linux-armv6.$(GO_VERSION)/$(BINARY) > release/$(BINARY)-$(VERSION).linux-armv6-sha256sum.txt
-	shasum -a 256 release/$(BINARY)-$(VERSION).windows-amd64.$(GO_VERSION)/$(BINARY) > release/$(BINARY)-$(VERSION).windows-amd64-sha256sum.txt
-	tar -C release -czvf release/$(BINARY)-$(VERSION).darwin-amd64.$(GO_VERSION).tar.gz $(BINARY)-$(VERSION).darwin-amd64.$(GO_VERSION)
-	tar -C release -czvf release/$(BINARY)-$(VERSION).linux-amd64.$(GO_VERSION).tar.gz $(BINARY)-$(VERSION).linux-amd64.$(GO_VERSION)
-	tar -C release -czvf release/$(BINARY)-$(VERSION).linux-arm64.$(GO_VERSION).tar.gz $(BINARY)-$(VERSION).linux-arm64.$(GO_VERSION)
-	tar -C release -czvf release/$(BINARY)-$(VERSION).linux-armv6.$(GO_VERSION).tar.gz $(BINARY)-$(VERSION).linux-armv6.$(GO_VERSION)
-	tar -C release -czvf release/$(BINARY)-$(VERSION).windows-amd64.$(GO_VERSION).tar.gz $(BINARY)-$(VERSION).windows-amd64.$(GO_VERSION)
+	BINARY=$(BINARY) VERSION=${VERSION} ./dist.sh

--- a/dist.sh
+++ b/dist.sh
@@ -22,7 +22,7 @@ mkdir -p release
 for ARCH in "${ARCHS[@]}"; do
 	mkdir -p release/${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}
 
-    GO_OS=$(echo $ARCH | awk -F- '{print $1}')
+	GO_OS=$(echo $ARCH | awk -F- '{print $1}')
 	GO_ARCH=$(echo $ARCH | awk -F- '{print $2}')
 
 	# Create architecture specific binaries

--- a/dist.sh
+++ b/dist.sh
@@ -1,45 +1,46 @@
-#!/bin/bash
-# build binary distributions for linux/amd64 and darwin/amd64
-set -e
+#!/usr/bin/env bash
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-echo "working dir $DIR"
-mkdir -p $DIR/dist
-dep ensure || exit 1
+set -o errexit
 
-os=$(go env GOOS)
-arch=$(go env GOARCH)
-version=$(cat $DIR/version.go | grep "const VERSION" | awk '{print $NF}' | sed 's/"//g')
-goversion=$(go version | awk '{print $3}')
-sha256sum=()
+if [[ -z ${BINARY} ]] || [[ -z ${VERSION} ]]; then
+	echo "Missing required env var: BINARY=X VERSION=X $(basename $0)"
+	exit 1
+fi
 
-echo "... running tests"
-./test.sh
+# Check for Go version 1.13.*
+GO_VERSION=$(go version | awk '{print $3}')
+if [[ ! "${GO_VERSION}" =~ ^go1.13.* ]]; then
+	echo "Go version must be >= go1.13"
+	exit 1
+fi
 
-for os in windows linux darwin; do
-    echo "... building v$version for $os/$arch"
-    EXT=
-    if [ $os = windows ]; then
-        EXT=".exe"
-    fi
-    BUILD=$(mktemp -d ${TMPDIR:-/tmp}/oauth2_proxy.XXXXXX)
-    TARGET="oauth2_proxy-$version.$os-$arch.$goversion"
-    FILENAME="oauth2_proxy-$version.$os-$arch$EXT"
-    GOOS=$os GOARCH=$arch CGO_ENABLED=0 \
-        go build -ldflags="-s -w" -o $BUILD/$TARGET/$FILENAME || exit 1
-    pushd $BUILD/$TARGET
-    sha256sum+=("$(shasum -a 256 $FILENAME || exit 1)")
-    cd .. && tar czvf $TARGET.tar.gz $TARGET
-    mv $TARGET.tar.gz $DIR/dist
-    popd
+ARCHS=(darwin-amd64 linux-amd64 linux-arm64 linux-armv6 windows-amd64)
+
+mkdir release
+
+# Create architecture specific release dirs
+for ARCH in "${ARCHS[@]}"; do
+	mkdir release/${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}
 done
 
-checksum_file="sha256sum.txt"
-cd $DIR/dist
-if [ -f $checksum_file ]; then
-    rm $checksum_file
-fi
-touch $checksum_file
-for checksum in "${sha256sum[@]}"; do
-    echo "$checksum" >> $checksum_file
+# Create architecture specific binaries
+GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" \
+	-o release/${BINARY}-${VERSION}.darwin-amd64.${GO_VERSION}/${BINARY} github.com/pusher/oauth2_proxy
+GO111MODULE=on GOOS=linux GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" \
+	-o release/${BINARY}-${VERSION}.linux-amd64.${GO_VERSION}/${BINARY} github.com/pusher/oauth2_proxy
+GO111MODULE=on GOOS=linux GOARCH=arm64 go build -ldflags="-X main.VERSION=${VERSION}" \
+	-o release/${BINARY}-${VERSION}.linux-arm64.${GO_VERSION}/${BINARY} github.com/pusher/oauth2_proxy
+GO111MODULE=on GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-X main.VERSION=${VERSION}" \
+	-o release/${BINARY}-${VERSION}.linux-armv6.${GO_VERSION}/${BINARY} github.com/pusher/oauth2_proxy
+GO111MODULE=on GOOS=windows GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" \
+	-o release/${BINARY}-${VERSION}.windows-amd64.${GO_VERSION}/${BINARY} github.com/pusher/oauth2_proxy
+
+cd release
+
+for ARCH in ${ARCHS[@]}; do
+	# Create sha256sum for architecture specific binary
+	shasum -a 256 ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}/${BINARY} > ${BINARY}-${VERSION}.${ARCH}-sha256sum.txt
+
+	# Create tar file for architecture specific binary
+	tar -czvf ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}.tar.gz ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}
 done

--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -9,7 +9,7 @@ nav_order: 1
 
 1.  Choose how to deploy:
 
-    a. Download [Prebuilt Binary](https://github.com/pusher/oauth2_proxy/releases) (current release is `v3.2.0`)
+    a. Download [Prebuilt Binary](https://github.com/pusher/oauth2_proxy/releases) (current release is `v4.0.0`)
 
     b. Build with `$ go get github.com/pusher/oauth2_proxy` which will put the binary in `$GOROOT/bin`
 
@@ -18,8 +18,8 @@ nav_order: 1
 Prebuilt binaries can be validated by extracting the file and verifying it against the `sha256sum.txt` checksum file provided for each release starting with version `v3.0.0`.
 
 ```
-sha256sum -c sha256sum.txt 2>&1 | grep OK
-oauth2_proxy-3.2.0.linux-amd64: OK
+$ sha256sum -c sha256sum.txt 2>&1 | grep OK
+oauth2_proxy-4.0.0.linux-amd64: OK
 ```
 
 2.  [Select a Provider and Register an OAuth Application with a Provider](auth-configuration)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #251 

## Motivation and Context

There was a small bug in the `make release` command that did not properly generate `SHA256` hashes. As the original `dist.sh` script was very outdated, I decided to merge the two.

## How Has This Been Tested?

Ran `dist.sh` on my machine and verified that all binaries are built and all `sha256sum` hashes are correct:

```
$ BINARY=oauth2_proxy VERSION=v4.0.0 ./dist.sh
oauth2_proxy-v4.0.0.darwin-amd64.go1.13.3/
oauth2_proxy-v4.0.0.darwin-amd64.go1.13.3/oauth2_proxy
oauth2_proxy-v4.0.0.linux-amd64.go1.13.3/
oauth2_proxy-v4.0.0.linux-amd64.go1.13.3/oauth2_proxy
oauth2_proxy-v4.0.0.linux-arm64.go1.13.3/
oauth2_proxy-v4.0.0.linux-arm64.go1.13.3/oauth2_proxy
oauth2_proxy-v4.0.0.linux-armv6.go1.13.3/
oauth2_proxy-v4.0.0.linux-armv6.go1.13.3/oauth2_proxy
oauth2_proxy-v4.0.0.windows-amd64.go1.13.3/
oauth2_proxy-v4.0.0.windows-amd64.go1.13.3/oauth2_proxy
$ cd release
$ sha256sum -c oauth2_proxy-v4.0.0.darwin-amd64-sha256sum.txt 2>&1
oauth2_proxy-v4.0.0.darwin-amd64.go1.13.3/oauth2_proxy: OK
$ sha256sum -c oauth2_proxy-v4.0.0.linux-amd64-sha256sum.txt 2>&1
oauth2_proxy-v4.0.0.linux-amd64.go1.13.3/oauth2_proxy: OK
$ sha256sum -c oauth2_proxy-v4.0.0.linux-arm64-sha256sum.txt 2>&1
oauth2_proxy-v4.0.0.linux-arm64.go1.13.3/oauth2_proxy: OK
$ sha256sum -c oauth2_proxy-v4.0.0.linux-armv6-sha256sum.txt 2>&1
oauth2_proxy-v4.0.0.linux-armv6.go1.13.3/oauth2_proxy: OK
$ sha256sum -c oauth2_proxy-v4.0.0.windows-amd64-sha256sum.txt 2>&1
oauth2_proxy-v4.0.0.windows-amd64.go1.13.3/oauth2_proxy: OK
```

@JoelSpeed @steakunderscore please run this script on you local machines in order to validate as part of the review.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
