### PR TITLE
Add bash completion script

### DIFF
--- a/contrib/oauth2_proxy_autocomplete.sh
+++ b/contrib/oauth2_proxy_autocomplete.sh
@@ -1,0 +1,23 @@
+_oauth2_proxy() {
+	_oauth2_proxy_commands=$(oauth2_proxy -h 2>&1 | sed -n '/^\s*-/s/ \+/ /gp' | awk '{print $1}' | tr '\n' ' ')
+	local cur prev
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	case "$prev" in
+		-@(config|tls-cert-file|tls-key-file|authenticated-emails-file|htpasswd-file|custom-templates-dir|logging-filename|jwt-key-file))
+			_filedir
+			return 0
+			;;
+		-provider)
+			COMPREPLY=( $(compgen -W "google azure facebook github keycloak gitlab linkedin login.gov" -- ${cur}) )
+			return 0
+			;;
+		-@(http-address|https-address|redirect-url|upstream|basic-auth-password|skip-auth-regex|flush-interval|extra-jwt-issuers|email-domain|whitelist-domain|keycloak-group|azure-tenant|bitbucket-team|bitbucket-repository|github-org|github-team|gitlab-group|google-group|google-admin-email|google-service-account-json|client-id|client_secret|banner|footer|proxy-prefix|ping-path|cookie-name|cookie-secret|cookie-domain|cookie-path|cookie-expire|cookie-refresh|redist-sentinel-master-name|redist-sentinel-connection-urls|logging-max-size|logging-max-age|logging-max-backups|standard-logging-format|request-logging-format|exclude-logging-paths|auth-logging-format|oidc-issuer-url|oidc-jwks-url|login-url|redeem-url|profile-url|resource|validate-url|scope|approval-prompt|signature-key|acr-values|jwt-key|pubjwk-url))
+			return 0
+			;;
+	esac
+	COMPREPLY=( $(compgen -W "${_oauth2_proxy_commands}" -- ${cur}) )
+	return 0;
+}
+complete -F _oauth2_proxy oauth2_proxy

--- a/contrib/oauth2_proxy_autocomplete.sh
+++ b/contrib/oauth2_proxy_autocomplete.sh
@@ -1,3 +1,10 @@
+#
+# Autocompletion for oauth2_proxy
+# 
+# To install this, copy/move this file to /etc/bash.completion.d/
+# or add a line to your ~/.bashrc | ~/.bash_profile that says ". /path/to/oauth2_proxy/contrib/oauth2_proxy_autocomplete.sh"
+#
+
 _oauth2_proxy() {
 	_oauth2_proxy_commands=$(oauth2_proxy -h 2>&1 | sed -n '/^\s*-/s/ \+/ /gp' | awk '{print $1}' | tr '\n' ' ')
 	local cur prev


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I added a bash completion script for oauth2_proxy. I put it in the contrib directory because I thought that might be appropriate. It autocompletes the flags themselves, `-provider` values, and files/directories for arguments that take a file as an input.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bash completion is nice and useful. It's definitely not a *required* change, which is why it's completely optional and is in the contrib directory.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this by sourcing the autocomplete script (`. ./contrib/oauth2_proxy_autocomplete.sh`) and then running things like `oauth2_proxy <tab>`, `oauth2_proxy -provider <tab>`, `oauth2_proxy -config <tab>`.

I looked into https://github.com/posener/complete as an alternative, but didn't want to add another dependency to something intended to be optional. If you want bash completion to be included by default, it might be something worth looking into.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

I'm not really sure about adding something to CHANGELOG. It would probably be good to put this somewhere in the docs so people can find it, maybe on the installation page?
- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
