### PR TITLE
Add support for Redis with custom CA.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [#302](https://github.com/pusher/oauth2_proxy/pull/302) Rewrite dist script (@syscll)
 - [#304](https://github.com/pusher/oauth2_proxy/pull/304) Add new Logo! :tada: (@JoelSpeed)
 - [#300](https://github.com/pusher/oauth2_proxy/pull/300) Added userinfo endpoint (@kbabuadze)
-
+- [#309](https://github.com/pusher/oauth2_proxy/pull/309) Added support for custom CA when connecting to Redis cache
 # v4.0.0
 
 - [#248](https://github.com/pusher/oauth2_proxy/pull/248) Fix issue with X-Auth-Request-Redirect header being ignored

--- a/main.go
+++ b/main.go
@@ -91,6 +91,8 @@ func main() {
 	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage (eg: redis://HOST[:PORT])")
 	flagSet.Bool("redis-use-sentinel", false, "Connect to redis via sentinels. Must set --redis-sentinel-master-name and --redis-sentinel-connection-urls to use this feature")
 	flagSet.String("redis-sentinel-master-name", "", "Redis sentinel master name. Used in conjunction with --redis-use-sentinel")
+	flagSet.String("redis-ca-path", "", "Redis custom CA path")
+	flagSet.Bool("redis-insecure-tls", false, "Use insecure TLS connection to redis")
 	flagSet.Var(&redisSentinelConnectionURLs, "redis-sentinel-connection-urls", "List of Redis sentinel connection URLs (eg redis://HOST[:PORT]). Used in conjunction with --redis-use-sentinel")
 
 	flagSet.String("logging-filename", "", "File to log requests to, empty for stdout")

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 	flagSet.Bool("redis-use-sentinel", false, "Connect to redis via sentinels. Must set --redis-sentinel-master-name and --redis-sentinel-connection-urls to use this feature")
 	flagSet.String("redis-sentinel-master-name", "", "Redis sentinel master name. Used in conjunction with --redis-use-sentinel")
 	flagSet.String("redis-ca-path", "", "Redis custom CA path")
-	flagSet.Bool("redis-insecure-tls", false, "Use insecure TLS connection to redis")
+	flagSet.Bool("redis-insecure-skip-tls-verify", false, "Use insecure TLS connection to redis")
 	flagSet.Var(&redisSentinelConnectionURLs, "redis-sentinel-connection-urls", "List of Redis sentinel connection URLs (eg redis://HOST[:PORT]). Used in conjunction with --redis-use-sentinel")
 
 	flagSet.String("logging-filename", "", "File to log requests to, empty for stdout")

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -27,4 +27,6 @@ type RedisStoreOptions struct {
 	UseSentinel            bool     `flag:"redis-use-sentinel" cfg:"redis_use_sentinel" env:"OAUTH2_PROXY_REDIS_USE_SENTINEL"`
 	SentinelMasterName     string   `flag:"redis-sentinel-master-name" cfg:"redis_sentinel_master_name" env:"OAUTH2_PROXY_REDIS_SENTINEL_MASTER_NAME"`
 	SentinelConnectionURLs []string `flag:"redis-sentinel-connection-urls" cfg:"redis_sentinel_connection_urls" env:"OAUTH2_PROXY_REDIS_SENTINEL_CONNECTION_URLS"`
+	RedisCAPath            string   `flag:"redis-ca-path" cfg:"redis_ca_path" env:"OAUTH2_PROXY_REDIS_CA_PATH"`
+	RedisInsecureTLS       bool     `flag:"redis-insecure-tls" cfg:"redis_insecure_tls" env:"OAUTH2_PROXY_REDIS_INSECURE_TLS"`
 }

--- a/pkg/apis/options/sessions.go
+++ b/pkg/apis/options/sessions.go
@@ -28,5 +28,5 @@ type RedisStoreOptions struct {
 	SentinelMasterName     string   `flag:"redis-sentinel-master-name" cfg:"redis_sentinel_master_name" env:"OAUTH2_PROXY_REDIS_SENTINEL_MASTER_NAME"`
 	SentinelConnectionURLs []string `flag:"redis-sentinel-connection-urls" cfg:"redis_sentinel_connection_urls" env:"OAUTH2_PROXY_REDIS_SENTINEL_CONNECTION_URLS"`
 	RedisCAPath            string   `flag:"redis-ca-path" cfg:"redis_ca_path" env:"OAUTH2_PROXY_REDIS_CA_PATH"`
-	RedisInsecureTLS       bool     `flag:"redis-insecure-tls" cfg:"redis_insecure_tls" env:"OAUTH2_PROXY_REDIS_INSECURE_TLS"`
+	RedisInsecureTLS       bool     `flag:"redis-insecure-skip-tls-verify" cfg:"redis_insecure_skip_tls_verify" env:"OAUTH2_PROXY_REDIS_INSECURE_SKIP_TLS_VERIFY"`
 }

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -72,7 +72,10 @@ func newRedisClient(opts options.RedisStoreOptions) (*redis.Client, error) {
 	}
 
 	if opts.RedisCAPath != "" {
-		rootCAs, _ := x509.SystemCertPool()
+		rootCAs, err := x509.SystemCertPool()
+		if err != nil {
+			logger.Printf("failed to load system cert pool for redis connection, falling back to empty cert pool")
+		}
 		if rootCAs == nil {
 			rootCAs = x509.NewCertPool()
 		}

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"github.com/pusher/oauth2_proxy/pkg/logger"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -20,6 +19,7 @@ import (
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
 	"github.com/pusher/oauth2_proxy/pkg/cookies"
 	"github.com/pusher/oauth2_proxy/pkg/encryption"
+	"github.com/pusher/oauth2_proxy/pkg/logger"
 )
 
 // TicketData is a structure representing the ticket used in server session storage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for custom CA for connecting to Redis cache.

## Motivation and Context
When running clusters with custom CA for issuing internal certificates redis certificate has to be added to oauth2_proxy, so it can connect to cache.

## How Has This Been Tested?
Oauth2_proxy configured to connect to redis configured with custom ca.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
