### PR TITLE
Store refresh token in cookie

### DIFF
--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -72,18 +72,19 @@
 
 
 ## Cookie Settings
-## Name     - the cookie name
-## Secret   - the seed string for secure cookies; should be 16, 24, or 32 bytes
-##            for use with an AES cipher when cookie_refresh or pass_access_token
-##            is set
-## Domain   - (optional) cookie domain to force cookies to (ie: .yourcompany.com)
-## Expire   - (duration) expire timeframe for cookie
-## Refresh  - (duration) refresh the cookie when duration has elapsed after cookie was initially set.
-##            Should be less than cookie_expire; set to 0 to disable.
-##            On refresh, OAuth token is re-validated. 
-##            (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
-## Secure   - secure cookies are only sent by the browser of a HTTPS connection (recommended)
-## HttpOnly - httponly cookies are not readable by javascript (recommended)
+## Name             - the cookie name
+## Secret           - the seed string for secure cookies; should be 16, 24, or 32 bytes
+##                    for use with an AES cipher when cookie_refresh or pass_access_token
+##                    is set
+## Domain           - (optional) cookie domain to force cookies to (ie: .yourcompany.com)
+## Expire           - (duration) expire timeframe for cookie
+## Refresh          - (duration) refresh the cookie when duration has elapsed after cookie was initially set.
+##                    Should be less than cookie_expire; set to 0 to disable.
+##                    On refresh, OAuth token is re-validated.
+##                    (ie: 1h means tokens are refreshed on request 1hr+ after it was set)
+## Secure           - secure cookies are only sent by the browser of a HTTPS connection (recommended)
+## HttpOnly         - httponly cookies are not readable by javascript (recommended)
+## RefreshTokenOnly - for redis storage type, allow to set refresh token in cookie (useful for not persistent redis)
 # cookie_name = "_oauth2_proxy"
 # cookie_secret = ""
 # cookie_domain = ""
@@ -91,3 +92,4 @@
 # cookie_refresh = ""
 # cookie_secure = true
 # cookie_httponly = true
+# cookie_refresh_token_only = false

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -41,6 +41,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-cookie-refresh` | duration | refresh the cookie after this duration; `0` to disable | |
 | `-cookie-secret` | string | the seed string for secure cookies (optionally base64 encoded) | |
 | `-cookie-secure` | bool | set [secure (HTTPS only) cookie flag](https://owasp.org/www-community/controls/SecureFlag) | true |
+| `-cookie-refresh-token-only` | bool | store refresh token in cookie (for redis storage type)| false |
 | `-cookie-samesite` | string | set SameSite cookie attribute (ie: `"lax"`, `"strict"`, `"none"`, or `""`). | `""` |
 | `-custom-templates-dir` | string | path to custom html templates | |
 | `-display-htpasswd-form` | bool | display username / password login form if an htpasswd file is provided | true |

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func main() {
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 	flagSet.String("cookie-samesite", "", "set SameSite cookie attribute (ie: \"lax\", \"strict\", \"none\", or \"\"). ")
+	flagSet.Bool("cookie-refresh-token-only", false, "store refresh token in cookie (worked with redis storage)")
 
 	flagSet.String("session-store-type", "cookie", "the session storage provider to use")
 	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage (eg: redis://HOST[:PORT])")

--- a/pkg/apis/options/cookie.go
+++ b/pkg/apis/options/cookie.go
@@ -4,13 +4,14 @@ import "time"
 
 // CookieOptions contains configuration options relating to Cookie configuration
 type CookieOptions struct {
-	CookieName     string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
-	CookieSecret   string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
-	CookieDomain   string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
-	CookiePath     string        `flag:"cookie-path" cfg:"cookie_path" env:"OAUTH2_PROXY_COOKIE_PATH"`
-	CookieExpire   time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
-	CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
-	CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure" env:"OAUTH2_PROXY_COOKIE_SECURE"`
-	CookieHTTPOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly" env:"OAUTH2_PROXY_COOKIE_HTTPONLY"`
-	CookieSameSite string        `flag:"cookie-samesite" cfg:"cookie_samesite" env:"OAUTH2_PROXY_COOKIE_SAMESITE"`
+	CookieName             string        `flag:"cookie-name" cfg:"cookie_name" env:"OAUTH2_PROXY_COOKIE_NAME"`
+	CookieSecret           string        `flag:"cookie-secret" cfg:"cookie_secret" env:"OAUTH2_PROXY_COOKIE_SECRET"`
+	CookieDomain           string        `flag:"cookie-domain" cfg:"cookie_domain" env:"OAUTH2_PROXY_COOKIE_DOMAIN"`
+	CookiePath             string        `flag:"cookie-path" cfg:"cookie_path" env:"OAUTH2_PROXY_COOKIE_PATH"`
+	CookieExpire           time.Duration `flag:"cookie-expire" cfg:"cookie_expire" env:"OAUTH2_PROXY_COOKIE_EXPIRE"`
+	CookieRefresh          time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
+	CookieSecure           bool          `flag:"cookie-secure" cfg:"cookie_secure" env:"OAUTH2_PROXY_COOKIE_SECURE"`
+	CookieHTTPOnly         bool          `flag:"cookie-httponly" cfg:"cookie_httponly" env:"OAUTH2_PROXY_COOKIE_HTTPONLY"`
+	CookieSameSite         string        `flag:"cookie-samesite" cfg:"cookie_samesite" env:"OAUTH2_PROXY_COOKIE_SAMESITE"`
+	CookieOnlyRefreshToken bool          `flag:"cookie-refresh-token-only" cfg:"cookie_refresh_token_only" env:"OAUTH2_PROXY_COOKIE_REFRESH_TOKEN_ONLY"`
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add ability to store refresh token in a cookie if Redis storage selected for sessions

Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

<!--- Describe your changes in detail -->

## Motivation and Context
There is a problem when we are using nonpersistent Redis for session storage. If Redis was killed or flushed, the user should be authenticated again. That makes oauth2 proxy to be stateful application (or sort of).

Storing refresh token in cookie adds the possibility to restore access- and id- token even if there is no data in Redis.

For example, I use oauth2 proxy in Kubernetes. Oauth2 proxy deployment contains Redis sidecar container. It's painful when the pod is evicted or killed. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the current feature in Kubernetes with oidc provider and two instances of oauth2 proxy.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.