### PR TITLE
Add redirect capability to sign_out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#300](https://github.com/pusher/oauth2_proxy/pull/300) Added userinfo endpoint (@kbabuadze)
 - [#309](https://github.com/pusher/oauth2_proxy/pull/309) Added support for custom CA when connecting to Redis cache (@lleszczu)
 - [#248](https://github.com/pusher/oauth2_proxy/pull/248) Fix issue with X-Auth-Request-Redirect header being ignored (@webnard)
+- [#314](https://github.com/pusher/oauth2_proxy/pull/314) Add redirect capability to sign_out (@costelmoraru)
 
 # v4.0.0
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -608,8 +608,14 @@ func (p *OAuthProxy) UserInfo(rw http.ResponseWriter, req *http.Request) {
 
 // SignOut sends a response to clear the authentication cookie
 func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
+	redirect, err := p.GetRedirect(req)
+	if err != nil {
+		logger.Printf("Error obtaining redirect: %s", err.Error())
+		p.ErrorPage(rw, 500, "Internal Error", err.Error())
+		return
+	}
 	p.ClearSessionCookie(rw, req)
-	http.Redirect(rw, req, "/", 302)
+	http.Redirect(rw, req, redirect, 302)
 }
 
 // OAuthStart starts the OAuth2 authentication flow


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix for the #311 

## Description

<!--- Describe your changes in detail -->
Added the redirect capability for the `sign_out` path.

## Motivation and Context

When installed multiple instances of oauth-proxy in the same k8s cluster, for example one instance for app1 and a second one for app2, after the sign_out, the request will get redirected to the same endpoint without the possibility to differenciate among the two paths.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested in our environments.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
