### PR TITLE
dist.sh: Add build for FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#248](https://github.com/pusher/oauth2_proxy/pull/248) Fix issue with X-Auth-Request-Redirect header being ignored (@webnard)
 - [#314](https://github.com/pusher/oauth2_proxy/pull/314) Add redirect capability to sign_out (@costelmoraru)
 - [#265](https://github.com/pusher/oauth2_proxy/pull/265) Add upstream with static response (@cgroschupp)
+- [#317](https://github.com/pusher/oauth2_proxy/pull/317) Add build for FreeBSD (@fnkr)
 
 # v4.0.0
 

--- a/dist.sh
+++ b/dist.sh
@@ -14,7 +14,7 @@ if [[ ! "${GO_VERSION}" =~ ^go1.13.* ]]; then
 	exit 1
 fi
 
-ARCHS=(darwin-amd64 linux-amd64 linux-arm64 linux-armv6 windows-amd64)
+ARCHS=(darwin-amd64 linux-amd64 linux-arm64 linux-armv6 freebsd-amd64 windows-amd64)
 
 mkdir -p release
 


### PR DESCRIPTION
## Description

Add build for FreeBSD-amd64.

## Motivation and Context

We're using pusher/oauth2_proxy on FreeBSD and would like to have official builds for it as well.

## How Has This Been Tested?

```sh
BINARY=oauth2_proxy VERSION=development ./dist.sh
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.