### PR TITLE
dist.sh: use sha256sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Breaking Changes
 
 ## Changes since v4.1.0
+- [#325](https://github.com/pusher/oauth2_proxy/pull/325) dist.sh: use sha256sum (@syscll)
 
 # v4.1.0
 

--- a/dist.sh
+++ b/dist.sh
@@ -37,7 +37,7 @@ for ARCH in "${ARCHS[@]}"; do
 	cd release
 
 	# Create sha256sum for architecture specific binary
-	shasum -a 256 ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}/${BINARY} > ${BINARY}-${VERSION}.${ARCH}-sha256sum.txt
+	sha256sum ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}/${BINARY} > ${BINARY}-${VERSION}.${ARCH}-sha256sum.txt
 
 	# Create tar file for architecture specific binary
 	tar -czvf ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}.tar.gz ${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use `sha256sum` instead of `shasum`.

## Motivation and Context

`sha256sum` is the newer tool.

## How Has This Been Tested?

Used this command to release v4.1.0

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
