### PR TITLE
Add reverse proxy setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## Breaking Changes
 
+- [#321](https://github.com/pusher/oauth2_proxy/pull/331) Add reverse proxy boolean flag to control whether headers like `X-Real-Ip` are accepted.
+  This defaults to false. **Usage behind a reverse proxy will require this flag to be set to avoid logging the reverse proxy IP address**.
+
 ## Changes since v4.1.0
 - [#325](https://github.com/pusher/oauth2_proxy/pull/325) dist.sh: use sha256sum (@syscll)
 

--- a/contrib/oauth2_proxy.cfg.example
+++ b/contrib/oauth2_proxy.cfg.example
@@ -5,6 +5,9 @@
 # http_address = "127.0.0.1:4180"
 # https_address = ":443"
 
+## Are we running behind a reverse proxy? Will not accept headers like X-Real-Ip unless this is set.
+# reverse_proxy = true
+
 ## TLS Settings
 # tls_cert_file = ""
 # tls_key_file = ""

--- a/docs/4_tls.md
+++ b/docs/4_tls.md
@@ -68,6 +68,7 @@ There are two recommended configurations.
        --cookie-secret=... \
        --cookie-secure=true \
        --provider=... \
+       --reverse-proxy=true \
        --client-id=... \
        --client-secret=...
     ```

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -90,6 +90,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-request-logging` | bool | Log requests | true |
 | `-request-logging-format` | string | Template for request log lines | see [Logging Configuration](#logging-configuration) |
 | `-resource` | string | The resource that is protected (Azure AD only) | |
+| `-reverse-proxy` | bool | are we running behind a reverse proxy, controls whether headers like X-Real-Ip are accepted | false | 
 | `-scope` | string | OAuth scope specification | |
 | `-session-store-type` | string | Session data storage backend | cookie |
 | `-set-xauthrequest` | bool | set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode) | false |
@@ -173,7 +174,7 @@ Available variables for auth logging:
 
 | Variable | Example | Description |
 | --- | --- | --- |
-| Client | 74.125.224.72 | The client/remote IP address. Will use the X-Real-IP header it if exists. |
+| Client | 74.125.224.72 | The client/remote IP address. Will use the X-Real-IP header it if exists & reverse-proxy is set to true. |
 | Host  | domain.com | The value of the Host header. |
 | Protocol | HTTP/1.0 | The request protocol. |
 | RequestMethod | GET | The request method. |
@@ -201,7 +202,7 @@ Available variables for request logging:
 
 | Variable | Example | Description |
 | --- | --- | --- |
-| Client | 74.125.224.72 | The client/remote IP address. Will use the X-Real-IP header it if exists. |
+| Client | 74.125.224.72 | The client/remote IP address. Will use the X-Real-IP header it if exists & reverse-proxy is set to true. |
 | Host  | domain.com | The value of the Host header. |
 | Protocol | HTTP/1.0 | The request protocol. |
 | RequestDuration | 0.001 | The time in seconds that a request took to process. |

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 
 	flagSet.String("http-address", "127.0.0.1:4180", "[http://]<addr>:<port> or unix://<path> to listen on for HTTP clients")
 	flagSet.String("https-address", ":443", "<addr>:<port> to listen on for HTTPS clients")
+	flagSet.Bool("reverse-proxy", false, "are we running behind a reverse proxy, controls whether headers like X-Real-Ip are accepted")
 	flagSet.Bool("force-https", false, "force HTTPS redirect for HTTP requests")
 	flagSet.String("tls-cert-file", "", "path to certificate file")
 	flagSet.String("tls-key-file", "", "path to private key file")

--- a/options.go
+++ b/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	ProxyWebSockets bool   `flag:"proxy-websockets" cfg:"proxy_websockets" env:"OAUTH2_PROXY_PROXY_WEBSOCKETS"`
 	HTTPAddress     string `flag:"http-address" cfg:"http_address" env:"OAUTH2_PROXY_HTTP_ADDRESS"`
 	HTTPSAddress    string `flag:"https-address" cfg:"https_address" env:"OAUTH2_PROXY_HTTPS_ADDRESS"`
+	ReverseProxy    bool   `flag:"reverse-proxy" cfg:"reverse_proxy" env:"OAUTH2_PROXY_REVERSE_PROXY"`
 	ForceHTTPS      bool   `flag:"force-https" cfg:"force_https" env:"OAUTH2_PROXY_FORCE_HTTPS"`
 	RedirectURL     string `flag:"redirect-url" cfg:"redirect_url" env:"OAUTH2_PROXY_REDIRECT_URL"`
 	ClientID        string `flag:"client-id" cfg:"client_id" env:"OAUTH2_PROXY_CLIENT_ID"`
@@ -611,6 +612,7 @@ func setupLogger(o *Options, msgs []string) []string {
 	logger.SetStandardTemplate(o.StandardLoggingFormat)
 	logger.SetAuthTemplate(o.AuthLoggingFormat)
 	logger.SetReqTemplate(o.RequestLoggingFormat)
+	logger.SetReverseProxy(o.ReverseProxy)
 
 	excludePaths := make([]string, 0)
 	excludePaths = append(excludePaths, strings.Split(o.ExcludeLoggingPaths, ",")...)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -153,7 +153,7 @@ func (l *Logger) PrintAuth(username string, req *http.Request, status AuthStatus
 		username = "-"
 	}
 
-	client := GetClient(l.reverseProxy, req)
+	client := GetClient(req, l.reverseProxy)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -201,7 +201,7 @@ func (l *Logger) PrintReq(username, upstream string, req *http.Request, url url.
 		}
 	}
 
-	client := GetClient(l.reverseProxy, req)
+	client := GetClient(req, l.reverseProxy)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -253,7 +253,7 @@ func (l *Logger) GetFileLineString(calldepth int) string {
 }
 
 // GetClient parses an HTTP request for the client/remote IP address.
-func GetClient(reverseProxy bool, req *http.Request) string {
+func GetClient(req *http.Request, reverseProxy bool) string {
 	client := req.RemoteAddr
 	if reverseProxy {
 		if ip := req.Header.Get("X-Real-IP"); ip != "" {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -88,6 +88,7 @@ type Logger struct {
 	stdEnabled     bool
 	authEnabled    bool
 	reqEnabled     bool
+	reverseProxy   bool
 	excludePaths   map[string]struct{}
 	stdLogTemplate *template.Template
 	authTemplate   *template.Template
@@ -102,6 +103,7 @@ func New(flag int) *Logger {
 		stdEnabled:     true,
 		authEnabled:    true,
 		reqEnabled:     true,
+		reverseProxy:   false,
 		excludePaths:   nil,
 		stdLogTemplate: template.Must(template.New("std-log").Parse(DefaultStandardLoggingFormat)),
 		authTemplate:   template.Must(template.New("auth-log").Parse(DefaultAuthLoggingFormat)),
@@ -151,7 +153,7 @@ func (l *Logger) PrintAuth(username string, req *http.Request, status AuthStatus
 		username = "-"
 	}
 
-	client := GetClient(req)
+	client := GetClient(l.reverseProxy, req)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -199,7 +201,7 @@ func (l *Logger) PrintReq(username, upstream string, req *http.Request, url url.
 		}
 	}
 
-	client := GetClient(req)
+	client := GetClient(l.reverseProxy, req)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -251,10 +253,12 @@ func (l *Logger) GetFileLineString(calldepth int) string {
 }
 
 // GetClient parses an HTTP request for the client/remote IP address.
-func GetClient(req *http.Request) string {
-	client := req.Header.Get("X-Real-IP")
-	if client == "" {
-		client = req.RemoteAddr
+func GetClient(reverseProxy bool, req *http.Request) string {
+	client := req.RemoteAddr
+	if reverseProxy {
+		if ip := req.Header.Get("X-Real-IP"); ip != "" {
+			client = ip
+		}
 	}
 
 	if c, _, err := net.SplitHostPort(client); err == nil {
@@ -306,6 +310,13 @@ func (l *Logger) SetReqEnabled(e bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.reqEnabled = e
+}
+
+// SetReverseProxy controls whether logging will trust headers that can be set by a reverse proxy.
+func (l *Logger) SetReverseProxy(e bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.reverseProxy = e
 }
 
 // SetExcludePaths sets the paths to exclude from logging.
@@ -379,6 +390,12 @@ func SetAuthEnabled(e bool) {
 // standard logger.
 func SetReqEnabled(e bool) {
 	std.SetReqEnabled(e)
+}
+
+// SetReverseProxy controls whether logging will trust headers that can be set
+// by a reverse proxy for the standard logger.
+func SetReverseProxy(e bool) {
+	std.SetReverseProxy(e)
 }
 
 // SetExcludePaths sets the path to exclude from logging, eg: health checks


### PR DESCRIPTION
## Description

Adds a new `ReverseProxy` option that controls whether the application accepts HTTP headers that can be set by a reverse proxy to indicate the real user etc. 

Currently, this only affects whether the logger respects the `X-Real-Ip` header. If set, this will be used if present. If not set, this will be ignored, even with a value as a malicious user could be trying to log a false IP address.

In the future this could also control other common headers, e.g. `X-Forwarded-For` etc. 

Big discussion point is that this is a **BREAKING CHANGE** for users currently behind a reverse proxy. The default value has been deliberately set to `false` as a user who runs this with a minimal configuration (without fully reading docs) should be left with a secure configuration by default. If being hosted behind a reverse proxy then this flag needs to be enabled. 

We should consider:

1.  Best way to communicate clear notice to existing users about breaking change
2. Should we temporarily leave default as `true` to allow for a period of bedding in then change to `false` after a suitable time? If so, how long?

## Motivation and Context

Corrects the security issue by always accepting the `X-Real-Ip` header (described in #321).

## How Has This Been Tested?

Quick and dirty test with curl - should be checked by others.

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.

Documentation has been updated but left the changelog until discussion has been had around best way to implement (if at all).