### PR TITLE
Support optional id_tokens in refresh responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 ## Breaking Changes
 
 ## Changes since v5.0.0
-- [#335](https://github.com/pusher/oauth2_proxy/pull/335) OIDC Provider support for empty id_tokens in the access token refresh response (@howzat)
 
+- [#335](https://github.com/pusher/oauth2_proxy/pull/335) OIDC Provider support for empty id_tokens in the access token refresh response (@howzat)
 - [#363](https://github.com/pusher/oauth2_proxy/pull/363) Extension of Redis Session Store to Support Redis Cluster (@yan-dblinf)
 - [#353](https://github.com/pusher/oauth2_proxy/pull/353) Fix login page fragment handling after soft reload on Firefox (@ffdybuster)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ## Important Notes
 - (Security) Fix for [open redirect vulnerability](https://github.com/pusher/oauth2_proxy/security/advisories/GHSA-qqxw-m5fj-f7gv)..  a bad actor using `/\` in redirect URIs can redirect a session to another domain
 
+- [#335] The session expiry for the OIDC provider is now taken from the Token Response (expires_in) rather than from the id_token (exp) 
 ## Breaking Changes
 
 - [#321](https://github.com/pusher/oauth2_proxy/pull/331) Add reverse proxy boolean flag to control whether headers like `X-Real-Ip` are accepted.
@@ -37,6 +38,7 @@
 - [#280](https://github.com/pusher/oauth2_proxy/pull/280) whitelisted redirect domains: add support for whitelisting specific ports or allowing wildcard ports (@kamaln7)
 - [#351](https://github.com/pusher/oauth2_proxy/pull/351) Add DigitalOcean Auth provider (@kamaln7)
 
+- [#335](https://github.com/pusher/oauth2_proxy/pull/335) OIDC Provider support for empty id_tokens in the access token refresh response (@howzat)
 # v4.1.0
 
 ## Release Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## Release Hightlights
 
 ## Important Notes
+- [#335] The session expiry for the OIDC provider is now taken from the Token Response (expires_in) rather than from the id_token (exp) 
 
 ## Breaking Changes
 
 ## Changes since v5.0.0
+- [#335](https://github.com/pusher/oauth2_proxy/pull/335) OIDC Provider support for empty id_tokens in the access token refresh response (@howzat)
 
 - [#353](https://github.com/pusher/oauth2_proxy/pull/353) Fix login page fragment handling after soft reload on Firefox (@ffdybuster)
 
@@ -21,7 +23,6 @@
 ## Important Notes
 - (Security) Fix for [open redirect vulnerability](https://github.com/pusher/oauth2_proxy/security/advisories/GHSA-qqxw-m5fj-f7gv)..  a bad actor using `/\` in redirect URIs can redirect a session to another domain
 
-- [#335] The session expiry for the OIDC provider is now taken from the Token Response (expires_in) rather than from the id_token (exp) 
 ## Breaking Changes
 
 - [#321](https://github.com/pusher/oauth2_proxy/pull/331) Add reverse proxy boolean flag to control whether headers like `X-Real-Ip` are accepted.
@@ -37,8 +38,6 @@
 - [#179](https://github.com/pusher/oauth2_proxy/pull/179) Add Nextcloud provider (@Ramblurr)
 - [#280](https://github.com/pusher/oauth2_proxy/pull/280) whitelisted redirect domains: add support for whitelisting specific ports or allowing wildcard ports (@kamaln7)
 - [#351](https://github.com/pusher/oauth2_proxy/pull/351) Add DigitalOcean Auth provider (@kamaln7)
-
-- [#335](https://github.com/pusher/oauth2_proxy/pull/335) OIDC Provider support for empty id_tokens in the access token refresh response (@howzat)
 # v4.1.0
 
 ## Release Highlights

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -42,28 +42,36 @@ func (p *OIDCProvider) Redeem(redirectURL, code string) (s *sessions.SessionStat
 	if err != nil {
 		return nil, fmt.Errorf("token exchange: %v", err)
 	}
-	s, err = p.createSessionState(ctx, token)
+
+	// in the initial exchange the id token is mandatory
+	idToken, err := p.findVerifiedIDToken(ctx, token)
+	if err != nil {
+		return nil, fmt.Errorf("could not verify id_token: %v", err)
+	} else if idToken == nil {
+		return nil, fmt.Errorf("token response did not contain an id_token")
+	}
+
+	s, err = p.createSessionState(token, idToken)
 	if err != nil {
 		return nil, fmt.Errorf("unable to update session: %v", err)
 	}
+
 	return
 }
 
 // RefreshSessionIfNeeded checks if the session has expired and uses the
-// RefreshToken to fetch a new ID token if required
+// RefreshToken to fetch a new Access Token (and optional ID token) if required
 func (p *OIDCProvider) RefreshSessionIfNeeded(s *sessions.SessionState) (bool, error) {
 	if s == nil || s.ExpiresOn.After(time.Now()) || s.RefreshToken == "" {
 		return false, nil
 	}
-
-	origExpiration := s.ExpiresOn
 
 	err := p.redeemRefreshToken(s)
 	if err != nil {
 		return false, fmt.Errorf("unable to redeem refresh token: %v", err)
 	}
 
-	fmt.Printf("refreshed id token %s (expired on %s)\n", s, origExpiration)
+	fmt.Printf("refreshed access token %s (expired on %s)\n", s, s.ExpiresOn)
 	return true, nil
 }
 
@@ -84,81 +92,84 @@ func (p *OIDCProvider) redeemRefreshToken(s *sessions.SessionState) (err error) 
 	if err != nil {
 		return fmt.Errorf("failed to get token: %v", err)
 	}
-	newSession, err := p.createSessionState(ctx, token)
+
+	// in the token refresh response the id_token is optional
+	idToken, err := p.findVerifiedIDToken(ctx, token)
 	if err != nil {
-		return fmt.Errorf("unable to update session: %v", err)
+		return fmt.Errorf("unable to extract id_token from response: %v", err)
 	}
+
+	newSession, err := p.createSessionState(token, idToken)
+	if err != nil {
+		return fmt.Errorf("unable create new session state from response: %v", err)
+	}
+
+	// It's possible that if the refresh token isn't in the token response the session will not contain an id token
+	// if it doesn't it's probably better to retain the old one
+	if newSession.IDToken != "" {
+		s.IDToken = newSession.IDToken
+		s.Email = newSession.Email
+		s.User = newSession.User
+	}
+
 	s.AccessToken = newSession.AccessToken
-	s.IDToken = newSession.IDToken
 	s.RefreshToken = newSession.RefreshToken
 	s.CreatedAt = newSession.CreatedAt
 	s.ExpiresOn = newSession.ExpiresOn
-	s.Email = newSession.Email
+
 	return
 }
 
-func (p *OIDCProvider) createSessionState(ctx context.Context, token *oauth2.Token) (*sessions.SessionState, error) {
-	rawIDToken, ok := token.Extra("id_token").(string)
-	if !ok {
-		return nil, fmt.Errorf("token response did not contain an id_token")
+func (p *OIDCProvider) findVerifiedIDToken(ctx context.Context, token *oauth2.Token) (*oidc.IDToken, error) {
+	getIDToken := func() (string, bool) {
+		rawIDToken, _ := token.Extra("id_token").(string)
+		return rawIDToken, len(rawIDToken) > 0
 	}
 
-	// Parse and verify ID Token payload.
-	idToken, err := p.Verifier.Verify(ctx, rawIDToken)
-	if err != nil {
-		return nil, fmt.Errorf("could not verify id_token: %v", err)
+	verifyIDToken := func(rawIdToken string) (*oidc.IDToken, error) {
+		return p.Verifier.Verify(ctx, rawIdToken)
 	}
 
-	// Extract custom claims.
-	var claims struct {
-		Subject  string `json:"sub"`
-		Email    string `json:"email"`
-		Verified *bool  `json:"email_verified"`
+	idToken, err := p.extractIDToken(getIDToken, verifyIDToken)
+	return idToken, err
+}
+
+func (p *OIDCProvider) extractIDToken(findIDToken GetIDTokenFn, verifyIDToken VerifyIDTokenFn) (*oidc.IDToken, error) {
+
+	if rawIDToken, present := findIDToken(); present {
+		return verifyIDToken(rawIDToken)
 	}
-	if err := idToken.Claims(&claims); err != nil {
-		return nil, fmt.Errorf("failed to parse id_token claims: %v", err)
-	}
 
-	if claims.Email == "" {
-		if p.ProfileURL.String() == "" {
-			return nil, fmt.Errorf("id_token did not contain an email")
-		}
+	return nil, nil
+}
 
-		// If the userinfo endpoint profileURL is defined, then there is a chance the userinfo
-		// contents at the profileURL contains the email.
-		// Make a query to the userinfo endpoint, and attempt to locate the email from there.
+func (p *OIDCProvider) createSessionState(token *oauth2.Token, idToken *oidc.IDToken) (*sessions.SessionState, error) {
 
-		req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
+	newSession := &sessions.SessionState{}
+
+	if idToken != nil {
+		claims, err := findClaimsFromIDToken(idToken, token.AccessToken, p.ProfileURL.String())
 		if err != nil {
-			return nil, err
-		}
-		req.Header = getOIDCHeader(token.AccessToken)
-
-		respJSON, err := requests.Request(req)
-		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("couldn't extract claims from id_token (%e)", err)
 		}
 
-		email, err := respJSON.Get("email").String()
-		if err != nil {
-			return nil, fmt.Errorf("Neither id_token nor userinfo endpoint contained an email")
-		}
+		if claims != nil {
 
-		claims.Email = email
-	}
-	if !p.AllowUnverifiedEmail && claims.Verified != nil && !*claims.Verified {
-		return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
+			if !p.AllowUnverifiedEmail && claims.Verified != nil && !*claims.Verified {
+				return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
+			}
+
+			newSession.IDToken = token.Extra("id_token").(string) // can this be derived from the object version
+			newSession.Email = claims.Email
+			newSession.User = claims.Subject
+		}
 	}
 
-	return &sessions.SessionState{
-		AccessToken:  token.AccessToken,
-		IDToken:      rawIDToken,
-		RefreshToken: token.RefreshToken,
-		CreatedAt:    time.Now(),
-		ExpiresOn:    idToken.Expiry,
-		Email:        claims.Email,
-		User:         claims.Subject,
-	}, nil
+	newSession.AccessToken = token.AccessToken
+	newSession.RefreshToken = token.RefreshToken
+	newSession.CreatedAt = time.Now()
+	newSession.ExpiresOn = token.Expiry
+	return newSession, nil
 }
 
 // ValidateSessionState checks that the session's IDToken is still valid
@@ -177,4 +188,52 @@ func getOIDCHeader(accessToken string) http.Header {
 	header.Set("Accept", "application/json")
 	header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 	return header
+}
+
+type GetIDTokenFn = func() (string, bool)
+type VerifyIDTokenFn = func(rawIdToken string) (*oidc.IDToken, error)
+
+func findClaimsFromIDToken(idToken *oidc.IDToken, accessToken string, profileURL string) (*OIDCClaims, error) {
+
+	// Extract custom claims.
+	claims := &OIDCClaims{}
+	if err := idToken.Claims(claims); err != nil {
+		return nil, fmt.Errorf("failed to parse id_token claims: %v", err)
+	}
+
+	if claims.Email == "" {
+		if profileURL == "" {
+			return nil, fmt.Errorf("id_token did not contain an email")
+		}
+
+		// If the userinfo endpoint profileURL is defined, then there is a chance the userinfo
+		// contents at the profileURL contains the email.
+		// Make a query to the userinfo endpoint, and attempt to locate the email from there.
+
+		req, err := http.NewRequest("GET", profileURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header = getOIDCHeader(accessToken)
+
+		respJSON, err := requests.Request(req)
+		if err != nil {
+			return nil, err
+		}
+
+		email, err := respJSON.Get("email").String()
+		if err != nil {
+			return nil, fmt.Errorf("neither id_token nor userinfo endpoint contained an email")
+		}
+
+		claims.Email = email
+	}
+
+	return claims, nil
+}
+
+type OIDCClaims struct {
+	Subject  string `json:"sub"`
+	Email    string `json:"email"`
+	Verified *bool  `json:"email_verified"`
 }

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -1,0 +1,332 @@
+package providers
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"golang.org/x/oauth2"
+
+	"github.com/bmizerany/assert"
+	"github.com/coreos/go-oidc"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+const accessToken = "access_token"
+const refreshToken = "refresh_token"
+const clientID = "https://test.myapp.com"
+const secret = "secret"
+
+// https://openid.net/specs/openid-connect-core-1_0.html#Claims
+type IDTokenClaims struct {
+	Subject  string `json:"sub"`
+	Email    string `json:"email"`
+	Verified *bool  `json:"email_verified"`
+	jwt.StandardClaims
+}
+type RedeemResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+	IDToken      string `json:"id_token,omitempty"`
+}
+
+func newIDToken(verified *bool) *IDTokenClaims {
+	return &IDTokenClaims{
+		"subject-id",
+		"janed@me.com",
+		verified,
+		jwt.StandardClaims{
+			Audience:  "https://test.myapp.com",
+			ExpiresAt: time.Now().Add(time.Hour).Unix(),
+			Id:        "id-some-id",
+			IssuedAt:  time.Now().Unix(),
+			Issuer:    "https://issuer.example.com",
+			NotBefore: 0,
+			Subject:   "123456789",
+		},
+	}
+}
+
+var verified = true
+var unverified = false
+var TestIDToken = newIDToken(&verified)
+
+type NoOpKeySet struct{}
+
+func (NoOpKeySet) VerifySignature(ctx context.Context, jwt string) (payload []byte, err error) {
+	payloadPart := strings.Split(jwt, ".")[1]
+	return base64.RawURLEncoding.DecodeString(payloadPart)
+}
+
+func newOIDCProvider(serverURL *url.URL) *OIDCProvider {
+	return &OIDCProvider{
+		ProviderData: &ProviderData{
+			ProviderName: "oidc",
+			ClientID:     clientID,
+			ClientSecret: secret,
+			RedeemURL: &url.URL{
+				Scheme: serverURL.Scheme,
+				Host:   serverURL.Host,
+				Path:   "/login/oauth/access_token"},
+			ProfileURL: &url.URL{
+				Scheme: serverURL.Scheme,
+				Host:   serverURL.Host,
+				Path:   "/profile"},
+			Scope: "openid profile offline_access"},
+		Verifier: oidc.NewVerifier(
+			"https://issuer.example.com",
+			NoOpKeySet{},
+			&oidc.Config{ClientID: clientID},
+		),
+	}
+}
+
+func newOIDCServer(body []byte) (*url.URL, *httptest.Server) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Add("content-type", "application/json")
+		rw.Write(body)
+	}))
+	url, _ := url.Parse(server.URL)
+	return url, server
+}
+
+func createRawIDToken(token *IDTokenClaims) (string, error) {
+
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	standardClaims := jwt.NewWithClaims(jwt.SigningMethodRS256, token)
+	return standardClaims.SignedString(key)
+}
+
+func createVerifiedIDToken(provider *OIDCProvider, rawIDToken string) (*oidc.IDToken, error) {
+	ctx := context.Background()
+	return provider.Verifier.Verify(ctx, rawIDToken)
+}
+
+func createOAuth2Token(rawIDToken string) (*oauth2.Token, error) {
+	token := oauth2.Token{
+		AccessToken:  accessToken,
+		TokenType:    "Bearer",
+		RefreshToken: refreshToken,
+		Expiry:       time.Now().Add(time.Minute),
+	}
+
+	tokenWithID := token.WithExtra(map[string]interface{}{
+		"id_token": rawIDToken,
+	})
+
+	return tokenWithID, nil
+}
+
+func Test_createSessionStateErrorsOnUnvalidatedEmail(t *testing.T) {
+
+	var server *httptest.Server
+	redeemURL, server := newOIDCServer(nil)
+	provider := newOIDCProvider(redeemURL)
+	defer server.Close()
+
+	rawIDToken, err := createRawIDToken(newIDToken(&unverified))
+	assert.Equal(t, nil, err)
+
+	tokenWithID, err := createOAuth2Token(rawIDToken)
+	assert.Equal(t, nil, err)
+
+	ctx := context.Background()
+	verifiedIDToken, err := provider.Verifier.Verify(ctx, rawIDToken)
+	assert.Equal(t, nil, err)
+
+	provider.AllowUnverifiedEmail = false
+	_, err = provider.createSessionState(tokenWithID, verifiedIDToken)
+	assert.Equal(t, errors.New("email in id_token (janed@me.com) isn't verified"), err)
+}
+
+func TestOIDCProviderRedeem(t *testing.T) {
+
+	rawIDToken, err := createRawIDToken(TestIDToken)
+	assert.Equal(t, nil, err)
+
+	body, err := json.Marshal(RedeemResponse{
+		AccessToken:  accessToken,
+		ExpiresIn:    10,
+		TokenType:    "Bearer",
+		RefreshToken: refreshToken,
+		IDToken:      rawIDToken,
+	})
+	assert.Equal(t, nil, err)
+
+	var server *httptest.Server
+	redeemURL, server := newOIDCServer(body)
+	provider := newOIDCProvider(redeemURL)
+	defer server.Close()
+
+	session, err := provider.Redeem(provider.RedeemURL.String(), "code1234")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, TestIDToken.Email, session.Email)
+	assert.Equal(t, accessToken, session.AccessToken)
+	assert.Equal(t, rawIDToken, session.IDToken)
+	assert.Equal(t, refreshToken, session.RefreshToken)
+	assert.Equal(t, TestIDToken.Subject, session.User)
+}
+
+func TestOIDCProviderRefreshSessionIfNeededWithoutIdToken(t *testing.T) {
+
+	rawIDToken, err := createRawIDToken(TestIDToken)
+	assert.Equal(t, nil, err)
+
+	body, err := json.Marshal(RedeemResponse{
+		AccessToken:  accessToken,
+		ExpiresIn:    10,
+		TokenType:    "Bearer",
+		RefreshToken: refreshToken,
+	})
+	assert.Equal(t, nil, err)
+
+	var server *httptest.Server
+	redeemURL, server := newOIDCServer(body)
+	provider := newOIDCProvider(redeemURL)
+	defer server.Close()
+
+	existingSession := &sessions.SessionState{
+		AccessToken:  "changeit",
+		IDToken:      rawIDToken,
+		CreatedAt:    time.Time{},
+		ExpiresOn:    time.Time{},
+		RefreshToken: refreshToken,
+		Email:        "janedoe@example.com",
+		User:         "123456789",
+	}
+	refreshed, err := provider.RefreshSessionIfNeeded(existingSession)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, refreshed, true)
+	assert.Equal(t, "janedoe@example.com", existingSession.Email)
+	assert.Equal(t, accessToken, existingSession.AccessToken)
+	assert.Equal(t, rawIDToken, existingSession.IDToken)
+	assert.Equal(t, refreshToken, existingSession.RefreshToken)
+	assert.Equal(t, "123456789", existingSession.User)
+}
+
+func TestOIDCProviderRefreshSessionIfNeededWithIdToken(t *testing.T) {
+
+	rawIDToken, err := createRawIDToken(TestIDToken)
+	assert.Equal(t, nil, err)
+
+	body, err := json.Marshal(RedeemResponse{
+		AccessToken:  accessToken,
+		ExpiresIn:    10,
+		TokenType:    "Bearer",
+		RefreshToken: refreshToken,
+		IDToken:      rawIDToken,
+	})
+	assert.Equal(t, nil, err)
+
+	var server *httptest.Server
+	redeemURL, server := newOIDCServer(body)
+	provider := newOIDCProvider(redeemURL)
+	defer server.Close()
+
+	existingSession := &sessions.SessionState{
+		AccessToken:  "changeit",
+		IDToken:      "changeit",
+		CreatedAt:    time.Time{},
+		ExpiresOn:    time.Time{},
+		RefreshToken: refreshToken,
+		Email:        "changeit",
+		User:         "changeit",
+	}
+	refreshed, err := provider.RefreshSessionIfNeeded(existingSession)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, true, refreshed)
+	assert.Equal(t, TestIDToken.Email, existingSession.Email)
+	assert.Equal(t, accessToken, existingSession.AccessToken)
+	assert.Equal(t, rawIDToken, existingSession.IDToken)
+	assert.Equal(t, refreshToken, existingSession.RefreshToken)
+	assert.Equal(t, TestIDToken.Subject, existingSession.User)
+}
+
+func TestOIDCProvider_findClaimsFromIDToken(t *testing.T) {
+	redeemURL, _ := newOIDCServer(nil)
+	provider := newOIDCProvider(redeemURL)
+
+	rawIDToken, err := createRawIDToken(TestIDToken)
+	assert.Equal(t, nil, err)
+
+	idToken, err := createVerifiedIDToken(provider, rawIDToken)
+	assert.Equal(t, nil, err)
+
+	foundIDToken, _ := findClaimsFromIDToken(idToken, accessToken, provider.ProfileURL.String())
+	assert.Equal(t, TestIDToken.Subject, foundIDToken.Subject)
+	assert.Equal(t, TestIDToken.Email, foundIDToken.Email)
+	assert.Equal(t, &verified, foundIDToken.Verified)
+}
+
+func TestOIDCProvider_findVerifiedIdToken(t *testing.T) {
+
+	ctx := context.Background()
+	someURL, _ := url.Parse("http://test.foo.com")
+	provider := newOIDCProvider(someURL)
+
+	rawIDToken, err := createRawIDToken(newIDToken(&verified))
+	assert.Equal(t, nil, err)
+
+	tokenWithID, err := createOAuth2Token(rawIDToken)
+	assert.Equal(t, nil, err)
+
+	token, err := createVerifiedIDToken(provider, rawIDToken)
+	assert.Equal(t, nil, err)
+
+	foundIDToken, err := provider.findVerifiedIDToken(ctx, tokenWithID)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, false, foundIDToken == nil)
+	assert.Equal(t, token.Subject, foundIDToken.Subject)
+	assert.Equal(t, token.Expiry.Unix(), foundIDToken.Expiry.Unix())
+	assert.Equal(t, token.Issuer, foundIDToken.Issuer)
+	assert.Equal(t, token.IssuedAt.Unix(), foundIDToken.IssuedAt.Unix())
+}
+
+func TestOIDCProvider_extractIDToken(t *testing.T) {
+
+	someURL, _ := url.Parse("http://test.foo.com")
+	provider := newOIDCProvider(someURL)
+
+	verifierFn := func(rawIdToken string) (*oidc.IDToken, error) {
+		switch {
+		case rawIdToken == "some-token":
+			return new(oidc.IDToken), nil
+		case rawIdToken == "error":
+			return nil, fmt.Errorf("kerblam")
+		default:
+			return nil, nil
+		}
+	}
+
+	findTokenFn := func(in string) func() (string, bool) {
+		return func() (string, bool) {
+			return in, len(in) > 0
+		}
+	}
+
+	token, err := provider.extractIDToken(findTokenFn("some-token"), verifierFn)
+	assert.Equal(t, new(oidc.IDToken), token)
+	assert.Equal(t, nil, err)
+
+	token, err = provider.extractIDToken(findTokenFn("error"), verifierFn)
+	assert.Equal(t, true, token == nil)
+	assert.Equal(t, fmt.Errorf("kerblam"), err)
+
+	token, err = provider.extractIDToken(findTokenFn(""), verifierFn)
+	assert.Equal(t, true, token == nil)
+	assert.Equal(t, nil, err)
+}

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"golang.org/x/oauth2"
 
 	"github.com/bmizerany/assert"
@@ -29,11 +28,10 @@ const refreshToken = "refresh_token"
 const clientID = "https://test.myapp.com"
 const secret = "secret"
 
-// https://openid.net/specs/openid-connect-core-1_0.html#Claims
 type IDTokenClaims struct {
-	Subject  string `json:"sub"`
-	Email    string `json:"email"`
-	Verified *bool  `json:"email_verified"`
+	Name    string `json:"name,omitempty"`
+	Email   string `json:"email,omitempty"`
+	Picture string `json:"picture,omitempty"`
 	jwt.StandardClaims
 }
 type RedeemResponse struct {
@@ -44,197 +42,170 @@ type RedeemResponse struct {
 	IDToken      string `json:"id_token,omitempty"`
 }
 
-func newIDToken(verified *bool) *IDTokenClaims {
-	return &IDTokenClaims{
-		"subject-id",
-		"janed@me.com",
-		verified,
-		jwt.StandardClaims{
-			Audience:  "https://test.myapp.com",
-			ExpiresAt: time.Now().Add(time.Hour).Unix(),
-			Id:        "id-some-id",
-			IssuedAt:  time.Now().Unix(),
-			Issuer:    "https://issuer.example.com",
-			NotBefore: 0,
-			Subject:   "123456789",
-		},
-	}
+var defaultIDToken IDTokenClaims = IDTokenClaims{
+	"Jane Dobbs",
+	"janed@me.com",
+	"http://mugbook.com/janed/me.jpg",
+	jwt.StandardClaims{
+		Audience:  "https://test.myapp.com",
+		ExpiresAt: time.Now().Add(time.Duration(5) * time.Minute).Unix(),
+		Id:        "id-some-id",
+		IssuedAt:  time.Now().Unix(),
+		Issuer:    "https://issuer.example.com",
+		NotBefore: 0,
+		Subject:   "123456789",
+	},
 }
 
-var verified = true
-var unverified = false
-var TestIDToken = newIDToken(&verified)
+type KeySetStub struct {}
 
-type NoOpKeySet struct{}
+func (c KeySetStub) VerifySignature(_ context.Context, jwt string) (payload []byte, err error) {
+	decodeString, err := base64.RawURLEncoding.DecodeString(strings.Split(jwt, ".")[1])
+	tokenClaims := &IDTokenClaims{}
+	err = json.Unmarshal(decodeString, tokenClaims)
 
-func (NoOpKeySet) VerifySignature(ctx context.Context, jwt string) (payload []byte, err error) {
-	payloadPart := strings.Split(jwt, ".")[1]
-	return base64.RawURLEncoding.DecodeString(payloadPart)
+	if err != nil || tokenClaims.Id == "this-id-fails-validation" {
+		return nil, fmt.Errorf("the validation failed for subject [%v]", tokenClaims.Subject)
+	}
+
+	return decodeString, err
 }
 
 func newOIDCProvider(serverURL *url.URL) *OIDCProvider {
-	return &OIDCProvider{
-		ProviderData: &ProviderData{
-			ProviderName: "oidc",
-			ClientID:     clientID,
-			ClientSecret: secret,
-			RedeemURL: &url.URL{
-				Scheme: serverURL.Scheme,
-				Host:   serverURL.Host,
-				Path:   "/login/oauth/access_token"},
-			ProfileURL: &url.URL{
-				Scheme: serverURL.Scheme,
-				Host:   serverURL.Host,
-				Path:   "/profile"},
-			Scope: "openid profile offline_access"},
-		Verifier: oidc.NewVerifier(
+
+	providerData := &ProviderData{
+		ProviderName: "oidc",
+		ClientID:     clientID,
+		ClientSecret: secret,
+		LoginURL: &url.URL{
+			Scheme: serverURL.Scheme,
+			Host:   serverURL.Host,
+			Path:   "/login/oauth/authorize"},
+		RedeemURL: &url.URL{
+			Scheme: serverURL.Scheme,
+			Host:   serverURL.Host,
+			Path:   "/login/oauth/access_token"},
+		ProfileURL: &url.URL{
+			Scheme: serverURL.Scheme,
+			Host:   serverURL.Host,
+			Path:   "/profile"},
+		ValidateURL: &url.URL{
+			Scheme: serverURL.Scheme,
+			Host:   serverURL.Host,
+			Path:   "/api"},
+		Scope: "openid profile offline_access"}
+
+	p := &OIDCProvider{
+		ProviderData: providerData,
+		Verifier:     oidc.NewVerifier(
 			"https://issuer.example.com",
-			NoOpKeySet{},
+			KeySetStub{},
 			&oidc.Config{ClientID: clientID},
 		),
 	}
+
+	return p
 }
 
 func newOIDCServer(body []byte) (*url.URL, *httptest.Server) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("content-type", "application/json")
-		rw.Write(body)
+		_, _ = rw.Write(body)
 	}))
-	url, _ := url.Parse(server.URL)
-	return url, server
+	u, _ := url.Parse(s.URL)
+	return u, s
 }
 
-func createRawIDToken(token *IDTokenClaims) (string, error) {
+func newSignedTestIDToken(tokenClaims IDTokenClaims) (string, error) {
 
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
-	standardClaims := jwt.NewWithClaims(jwt.SigningMethodRS256, token)
+	standardClaims := jwt.NewWithClaims(jwt.SigningMethodRS256, tokenClaims)
 	return standardClaims.SignedString(key)
 }
 
-func createVerifiedIDToken(provider *OIDCProvider, rawIDToken string) (*oidc.IDToken, error) {
-	ctx := context.Background()
-	return provider.Verifier.Verify(ctx, rawIDToken)
-}
-
-func createOAuth2Token(rawIDToken string) (*oauth2.Token, error) {
-	token := oauth2.Token{
+func newOauth2Token() *oauth2.Token {
+	return &oauth2.Token{
 		AccessToken:  accessToken,
 		TokenType:    "Bearer",
 		RefreshToken: refreshToken,
-		Expiry:       time.Now().Add(time.Minute),
+		Expiry:       time.Time{}.Add(time.Duration(5) * time.Second),
 	}
-
-	tokenWithID := token.WithExtra(map[string]interface{}{
-		"id_token": rawIDToken,
-	})
-
-	return tokenWithID, nil
 }
 
-func Test_createSessionStateErrorsOnUnvalidatedEmail(t *testing.T) {
-
-	var server *httptest.Server
-	redeemURL, server := newOIDCServer(nil)
+func newTestSetup(body []byte) (*httptest.Server, *OIDCProvider) {
+	redeemURL, server := newOIDCServer(body)
 	provider := newOIDCProvider(redeemURL)
-	defer server.Close()
-
-	rawIDToken, err := createRawIDToken(newIDToken(&unverified))
-	assert.Equal(t, nil, err)
-
-	tokenWithID, err := createOAuth2Token(rawIDToken)
-	assert.Equal(t, nil, err)
-
-	ctx := context.Background()
-	verifiedIDToken, err := provider.Verifier.Verify(ctx, rawIDToken)
-	assert.Equal(t, nil, err)
-
-	provider.AllowUnverifiedEmail = false
-	_, err = provider.createSessionState(tokenWithID, verifiedIDToken)
-	assert.Equal(t, errors.New("email in id_token (janed@me.com) isn't verified"), err)
+	return server, provider
 }
 
 func TestOIDCProviderRedeem(t *testing.T) {
 
-	rawIDToken, err := createRawIDToken(TestIDToken)
-	assert.Equal(t, nil, err)
-
-	body, err := json.Marshal(RedeemResponse{
+	idToken, _ := newSignedTestIDToken(defaultIDToken)
+	body, _ := json.Marshal(RedeemResponse{
 		AccessToken:  accessToken,
 		ExpiresIn:    10,
 		TokenType:    "Bearer",
 		RefreshToken: refreshToken,
-		IDToken:      rawIDToken,
+		IDToken:      idToken,
 	})
-	assert.Equal(t, nil, err)
 
-	var server *httptest.Server
-	redeemURL, server := newOIDCServer(body)
-	provider := newOIDCProvider(redeemURL)
+	server, provider := newTestSetup(body)
 	defer server.Close()
 
 	session, err := provider.Redeem(provider.RedeemURL.String(), "code1234")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, TestIDToken.Email, session.Email)
+	assert.Equal(t, defaultIDToken.Email, session.Email)
 	assert.Equal(t, accessToken, session.AccessToken)
-	assert.Equal(t, rawIDToken, session.IDToken)
+	assert.Equal(t, idToken, session.IDToken)
 	assert.Equal(t, refreshToken, session.RefreshToken)
-	assert.Equal(t, TestIDToken.Subject, session.User)
+	assert.Equal(t, "123456789", session.User)
 }
 
 func TestOIDCProviderRefreshSessionIfNeededWithoutIdToken(t *testing.T) {
 
-	rawIDToken, err := createRawIDToken(TestIDToken)
-	assert.Equal(t, nil, err)
-
-	body, err := json.Marshal(RedeemResponse{
+	idToken, _ := newSignedTestIDToken(defaultIDToken)
+	body, _ := json.Marshal(RedeemResponse{
 		AccessToken:  accessToken,
 		ExpiresIn:    10,
 		TokenType:    "Bearer",
 		RefreshToken: refreshToken,
 	})
-	assert.Equal(t, nil, err)
 
-	var server *httptest.Server
-	redeemURL, server := newOIDCServer(body)
-	provider := newOIDCProvider(redeemURL)
+	server, provider := newTestSetup(body)
 	defer server.Close()
 
 	existingSession := &sessions.SessionState{
 		AccessToken:  "changeit",
-		IDToken:      rawIDToken,
+		IDToken:      idToken,
 		CreatedAt:    time.Time{},
 		ExpiresOn:    time.Time{},
 		RefreshToken: refreshToken,
 		Email:        "janedoe@example.com",
-		User:         "123456789",
+		User:         "11223344",
 	}
+
 	refreshed, err := provider.RefreshSessionIfNeeded(existingSession)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, refreshed, true)
 	assert.Equal(t, "janedoe@example.com", existingSession.Email)
 	assert.Equal(t, accessToken, existingSession.AccessToken)
-	assert.Equal(t, rawIDToken, existingSession.IDToken)
+	assert.Equal(t, idToken, existingSession.IDToken)
 	assert.Equal(t, refreshToken, existingSession.RefreshToken)
-	assert.Equal(t, "123456789", existingSession.User)
+	assert.Equal(t, "11223344", existingSession.User)
 }
 
 func TestOIDCProviderRefreshSessionIfNeededWithIdToken(t *testing.T) {
 
-	rawIDToken, err := createRawIDToken(TestIDToken)
-	assert.Equal(t, nil, err)
-
-	body, err := json.Marshal(RedeemResponse{
+	idToken, _ := newSignedTestIDToken(defaultIDToken)
+	body, _ := json.Marshal(RedeemResponse{
 		AccessToken:  accessToken,
 		ExpiresIn:    10,
 		TokenType:    "Bearer",
 		RefreshToken: refreshToken,
-		IDToken:      rawIDToken,
+		IDToken:      idToken,
 	})
-	assert.Equal(t, nil, err)
 
-	var server *httptest.Server
-	redeemURL, server := newOIDCServer(body)
-	provider := newOIDCProvider(redeemURL)
+	server, provider := newTestSetup(body)
 	defer server.Close()
 
 	existingSession := &sessions.SessionState{
@@ -248,85 +219,45 @@ func TestOIDCProviderRefreshSessionIfNeededWithIdToken(t *testing.T) {
 	}
 	refreshed, err := provider.RefreshSessionIfNeeded(existingSession)
 	assert.Equal(t, nil, err)
-	assert.Equal(t, true, refreshed)
-	assert.Equal(t, TestIDToken.Email, existingSession.Email)
+	assert.Equal(t, refreshed, true)
+	assert.Equal(t, defaultIDToken.Email, existingSession.Email)
+	assert.Equal(t, defaultIDToken.Subject, existingSession.User)
 	assert.Equal(t, accessToken, existingSession.AccessToken)
-	assert.Equal(t, rawIDToken, existingSession.IDToken)
+	assert.Equal(t, idToken, existingSession.IDToken)
 	assert.Equal(t, refreshToken, existingSession.RefreshToken)
-	assert.Equal(t, TestIDToken.Subject, existingSession.User)
-}
-
-func TestOIDCProvider_findClaimsFromIDToken(t *testing.T) {
-	redeemURL, _ := newOIDCServer(nil)
-	provider := newOIDCProvider(redeemURL)
-
-	rawIDToken, err := createRawIDToken(TestIDToken)
-	assert.Equal(t, nil, err)
-
-	idToken, err := createVerifiedIDToken(provider, rawIDToken)
-	assert.Equal(t, nil, err)
-
-	foundIDToken, _ := findClaimsFromIDToken(idToken, accessToken, provider.ProfileURL.String())
-	assert.Equal(t, TestIDToken.Subject, foundIDToken.Subject)
-	assert.Equal(t, TestIDToken.Email, foundIDToken.Email)
-	assert.Equal(t, &verified, foundIDToken.Verified)
 }
 
 func TestOIDCProvider_findVerifiedIdToken(t *testing.T) {
 
-	ctx := context.Background()
-	someURL, _ := url.Parse("http://test.foo.com")
-	provider := newOIDCProvider(someURL)
+	server, provider := newTestSetup([]byte(""))
 
-	rawIDToken, err := createRawIDToken(newIDToken(&verified))
+	defer server.Close()
+
+	token := newOauth2Token()
+	signedIdToken, _ := newSignedTestIDToken(defaultIDToken)
+	tokenWithIdToken := token.WithExtra(map[string]interface{}{
+		"id_token": signedIdToken,
+	})
+
+	verifiedIdToken, err := provider.findVerifiedIDToken(context.Background(), tokenWithIdToken)
+	assert.Equal(t, true, err == nil)
+	assert.Equal(t, true, verifiedIdToken != nil)
+	assert.Equal(t, defaultIDToken.Issuer, verifiedIdToken.Issuer)
+	assert.Equal(t, defaultIDToken.Subject, verifiedIdToken.Subject)
+
+	// When the validation fails the response should be nil
+	defaultIDToken.Id = "this-id-fails-validation"
+	signedIdToken, _ = newSignedTestIDToken(defaultIDToken)
+	tokenWithIdToken = token.WithExtra(map[string]interface{}{
+		"id_token": signedIdToken,
+	})
+
+	verifiedIdToken, err = provider.findVerifiedIDToken(context.Background(), tokenWithIdToken)
+	assert.Equal(t, errors.New("failed to verify signature: the validation failed for subject [123456789]"), err)
+	assert.Equal(t, true, verifiedIdToken == nil)
+
+	// When there is no id token in the oauth token
+	verifiedIdToken, err = provider.findVerifiedIDToken(context.Background(), newOauth2Token())
 	assert.Equal(t, nil, err)
-
-	tokenWithID, err := createOAuth2Token(rawIDToken)
-	assert.Equal(t, nil, err)
-
-	token, err := createVerifiedIDToken(provider, rawIDToken)
-	assert.Equal(t, nil, err)
-
-	foundIDToken, err := provider.findVerifiedIDToken(ctx, tokenWithID)
-	assert.Equal(t, nil, err)
-	assert.Equal(t, false, foundIDToken == nil)
-	assert.Equal(t, token.Subject, foundIDToken.Subject)
-	assert.Equal(t, token.Expiry.Unix(), foundIDToken.Expiry.Unix())
-	assert.Equal(t, token.Issuer, foundIDToken.Issuer)
-	assert.Equal(t, token.IssuedAt.Unix(), foundIDToken.IssuedAt.Unix())
-}
-
-func TestOIDCProvider_extractIDToken(t *testing.T) {
-
-	someURL, _ := url.Parse("http://test.foo.com")
-	provider := newOIDCProvider(someURL)
-
-	verifierFn := func(rawIdToken string) (*oidc.IDToken, error) {
-		switch {
-		case rawIdToken == "some-token":
-			return new(oidc.IDToken), nil
-		case rawIdToken == "error":
-			return nil, fmt.Errorf("kerblam")
-		default:
-			return nil, nil
-		}
-	}
-
-	findTokenFn := func(in string) func() (string, bool) {
-		return func() (string, bool) {
-			return in, len(in) > 0
-		}
-	}
-
-	token, err := provider.extractIDToken(findTokenFn("some-token"), verifierFn)
-	assert.Equal(t, new(oidc.IDToken), token)
-	assert.Equal(t, nil, err)
-
-	token, err = provider.extractIDToken(findTokenFn("error"), verifierFn)
-	assert.Equal(t, true, token == nil)
-	assert.Equal(t, fmt.Errorf("kerblam"), err)
-
-	token, err = provider.extractIDToken(findTokenFn(""), verifierFn)
-	assert.Equal(t, true, token == nil)
-	assert.Equal(t, nil, err)
+	assert.Equal(t, true, verifiedIdToken == nil)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Allowing refresh requests to succeed when no id_token is provided in the response
This PR makes the following changes
- When refreshing the access_token if no id_token is supplied the access_token will still be refreshed and updated in the session. If an id_token is also provided then the session is also populated with that information (presuming the token is successfully validated)
- The expiry time of the session is now taken from the **outh** token expiry and _not_ the id_token. It is not uncommon for access tokens have a relatively short expiry time, since they can be extended using the refresh. Using the expiry time as defined on the id_token leads to a situation where access tokens are expiring long before the id_token. The session is then effectively broken since it contains an expired access_token that will not be refreshed until such time as the id_token expires.
- The code has been refactored to allow for better unit test coverage
- The major paths of Redeeming and Refreshing the access token have some test coverage

## Motivation and Context
This change is to address the bug raised https://github.com/pusher/oauth2_proxy/issues/318

## How Has This Been Tested?
The tests that exercise the Redeem and RefreshTokenIfNeeded paths have also been run against the current master _oidc.go_  and then against this branch to verify the red/green  behaviour changes are happening as expected.

I've run the oauth2_proxy locally using an Okta App/Authorisation server. I've been able to see the Redeem and Refresh paths working for token responses that _do_ include id_token. I've also deployed my own fork into our context and observed it working when no id token is present in the refresh response.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
