### PR TITLE
Add configuration for cookie 'SameSite' value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Breaking Changes
 
 ## Changes since v4.1.0
+- [#338](https://github.com/pusher/oauth2_proxy/pull/338) Add configuration for cookie 'SameSite' value. (@pgroudas)
 - [#325](https://github.com/pusher/oauth2_proxy/pull/325) dist.sh: use sha256sum (@syscll)
 - [#179](https://github.com/pusher/oauth2_proxy/pull/179) Add Nextcloud provider (@Ramblurr)
 

--- a/contrib/oauth2_proxy_autocomplete.sh
+++ b/contrib/oauth2_proxy_autocomplete.sh
@@ -1,6 +1,6 @@
 #
 # Autocompletion for oauth2_proxy
-# 
+#
 # To install this, copy/move this file to /etc/bash.completion.d/
 # or add a line to your ~/.bashrc | ~/.bash_profile that says ". /path/to/oauth2_proxy/contrib/oauth2_proxy_autocomplete.sh"
 #
@@ -20,7 +20,7 @@ _oauth2_proxy() {
 			COMPREPLY=( $(compgen -W "google azure facebook github keycloak gitlab linkedin login.gov" -- ${cur}) )
 			return 0
 			;;
-		-@(http-address|https-address|redirect-url|upstream|basic-auth-password|skip-auth-regex|flush-interval|extra-jwt-issuers|email-domain|whitelist-domain|keycloak-group|azure-tenant|bitbucket-team|bitbucket-repository|github-org|github-team|gitlab-group|google-group|google-admin-email|google-service-account-json|client-id|client_secret|banner|footer|proxy-prefix|ping-path|cookie-name|cookie-secret|cookie-domain|cookie-path|cookie-expire|cookie-refresh|redist-sentinel-master-name|redist-sentinel-connection-urls|logging-max-size|logging-max-age|logging-max-backups|standard-logging-format|request-logging-format|exclude-logging-paths|auth-logging-format|oidc-issuer-url|oidc-jwks-url|login-url|redeem-url|profile-url|resource|validate-url|scope|approval-prompt|signature-key|acr-values|jwt-key|pubjwk-url))
+		-@(http-address|https-address|redirect-url|upstream|basic-auth-password|skip-auth-regex|flush-interval|extra-jwt-issuers|email-domain|whitelist-domain|keycloak-group|azure-tenant|bitbucket-team|bitbucket-repository|github-org|github-team|gitlab-group|google-group|google-admin-email|google-service-account-json|client-id|client_secret|banner|footer|proxy-prefix|ping-path|cookie-name|cookie-secret|cookie-domain|cookie-path|cookie-expire|cookie-refresh|cookie-samesite|redist-sentinel-master-name|redist-sentinel-connection-urls|logging-max-size|logging-max-age|logging-max-backups|standard-logging-format|request-logging-format|exclude-logging-paths|auth-logging-format|oidc-issuer-url|oidc-jwks-url|login-url|redeem-url|profile-url|resource|validate-url|scope|approval-prompt|signature-key|acr-values|jwt-key|pubjwk-url))
 			return 0
 			;;
 	esac

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -38,6 +38,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-cookie-refresh` | duration | refresh the cookie after this duration; `0` to disable | |
 | `-cookie-secret` | string | the seed string for secure cookies (optionally base64 encoded) | |
 | `-cookie-secure` | bool | set secure (HTTPS) cookie flag | true |
+| `-cookie-samesite` | string | an optional cookie SameSite Value (ie: `lax`, `strict`, or `none`) | |
 | `-custom-templates-dir` | string | path to custom html templates | |
 | `-display-htpasswd-form` | bool | display username / password login form if an htpasswd file is provided | true |
 | `-email-domain` | string | authenticate emails with the specified domain (may be given multiple times). Use `*` to authenticate any email | |

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	jwtIssuers := StringArray{}
 	googleGroups := StringArray{}
 	redisSentinelConnectionURLs := StringArray{}
+	cookieSameSite := SameSiteValue{sameSite: http.SameSiteDefaultMode}
 
 	config := flagSet.String("config", "", "path to config file")
 	showVersion := flagSet.Bool("version", false, "print version string")
@@ -86,6 +87,7 @@ func main() {
 	flagSet.Duration("cookie-refresh", time.Duration(0), "refresh the cookie after this duration; 0 to disable")
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
+	flagSet.Var(&cookieSameSite, "cookie-samesite", "an optional cookie SameSite Value (ie: 'lax', 'strict', or 'none')")
 
 	flagSet.String("session-store-type", "cookie", "the session storage provider to use")
 	flagSet.String("redis-connection-url", "", "URL of redis server for redis session storage (eg: redis://HOST[:PORT])")

--- a/options.go
+++ b/options.go
@@ -155,6 +155,7 @@ func NewOptions() *Options {
 			CookieHTTPOnly: true,
 			CookieExpire:   time.Duration(168) * time.Hour,
 			CookieRefresh:  time.Duration(0),
+			CookieSameSite: http.SameSiteDefaultMode,
 		},
 		SessionOptions: options.SessionOptions{
 			Type: "cookie",

--- a/pkg/apis/options/cookie.go
+++ b/pkg/apis/options/cookie.go
@@ -1,6 +1,9 @@
 package options
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 // CookieOptions contains configuration options relating to Cookie configuration
 type CookieOptions struct {
@@ -12,4 +15,5 @@ type CookieOptions struct {
 	CookieRefresh  time.Duration `flag:"cookie-refresh" cfg:"cookie_refresh" env:"OAUTH2_PROXY_COOKIE_REFRESH"`
 	CookieSecure   bool          `flag:"cookie-secure" cfg:"cookie_secure" env:"OAUTH2_PROXY_COOKIE_SECURE"`
 	CookieHTTPOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly" env:"OAUTH2_PROXY_COOKIE_HTTPONLY"`
+	CookieSameSite http.SameSite `flag:"cookie-samesite" cfg:"cookie_samesite" env:"OAUTH2_PROXY_COOKIE_SAMESITE"`
 }

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -12,7 +12,7 @@ import (
 
 // MakeCookie constructs a cookie from the given parameters,
 // discovering the domain from the request if not specified.
-func MakeCookie(req *http.Request, name string, value string, path string, domain string, httpOnly bool, secure bool, expiration time.Duration, now time.Time) *http.Cookie {
+func MakeCookie(req *http.Request, name string, value string, path string, domain string, httpOnly bool, secure bool, sameSite http.SameSite, expiration time.Duration, now time.Time) *http.Cookie {
 	if domain != "" {
 		host := req.Host
 		if h, _, err := net.SplitHostPort(host); err == nil {
@@ -31,11 +31,12 @@ func MakeCookie(req *http.Request, name string, value string, path string, domai
 		HttpOnly: httpOnly,
 		Secure:   secure,
 		Expires:  now.Add(expiration),
+		SameSite: sameSite,
 	}
 }
 
 // MakeCookieFromOptions constructs a cookie based on the givemn *options.CookieOptions,
 // value and creation time
 func MakeCookieFromOptions(req *http.Request, name string, value string, opts *options.CookieOptions, expiration time.Duration, now time.Time) *http.Cookie {
-	return MakeCookie(req, name, value, opts.CookiePath, opts.CookieDomain, opts.CookieHTTPOnly, opts.CookieSecure, expiration, now)
+	return MakeCookie(req, name, value, opts.CookiePath, opts.CookieDomain, opts.CookieHTTPOnly, opts.CookieSecure, opts.CookieSameSite, expiration, now)
 }

--- a/pkg/sessions/session_store_test.go
+++ b/pkg/sessions/session_store_test.go
@@ -79,6 +79,12 @@ var _ = Describe("NewSessionStore", func() {
 				}
 			})
 
+			It("have the correct SameSite set", func() {
+				for _, cookie := range cookies {
+					Expect(cookie.SameSite).To(Equal(cookieOpts.CookieSameSite))
+				}
+			})
+
 			It("have a signature timestamp matching session.CreatedAt", func() {
 				for _, cookie := range cookies {
 					if cookie.Value != "" {
@@ -338,6 +344,7 @@ var _ = Describe("NewSessionStore", func() {
 					CookieSecure:   false,
 					CookieHTTPOnly: false,
 					CookieDomain:   "example.com",
+					CookieSameSite: http.SameSiteLaxMode,
 				}
 
 				var err error
@@ -379,6 +386,7 @@ var _ = Describe("NewSessionStore", func() {
 			CookieRefresh:  time.Duration(1) * time.Hour,
 			CookieSecure:   true,
 			CookieHTTPOnly: true,
+			CookieSameSite: http.SameSiteDefaultMode,
 		}
 
 		session = &sessionsapi.SessionState{

--- a/samesite.go
+++ b/samesite.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"net/http"
+)
+
+// SameSiteValue is wrapper for the http.SameSite enum
+type SameSiteValue struct {
+	sameSite http.SameSite
+}
+
+// Get returns a http.SameSite
+func (v *SameSiteValue) Get() interface{} {
+	return v.sameSite
+}
+
+// Set converts the string config value into the SameSiteValue
+func (v *SameSiteValue) Set(s string) error {
+	switch s {
+	case "lax":
+		v.sameSite = http.SameSiteLaxMode
+	case "strict":
+		v.sameSite = http.SameSiteStrictMode
+	case "none":
+		v.sameSite = http.SameSiteNoneMode
+	default:
+		v.sameSite = http.SameSiteDefaultMode
+	}
+	return nil
+}
+
+// String returns a string representation of the SameSiteValue
+func (v *SameSiteValue) String() string {
+	switch v.sameSite {
+	case http.SameSiteLaxMode:
+		return "lax"
+	case http.SameSiteStrictMode:
+		return "strict"
+	case http.SameSiteNoneMode:
+		return "none"
+	case http.SameSiteDefaultMode:
+		return ""
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
Values of 'lax' and 'strict' can improve and mitigate
some categories of cross-site traffic tampering.

Given that the nature of this proxy is often to proxy
private tools, this is useful to take advantage of.

See: https://www.owasp.org/index.php/SameSite

<!--- Provide a general summary of your changes in the Title above -->

## Description

This extends the configuration options to add an additional field for COOKIE_SAMESITE
which will be propagated into options used to configure the authentication / session cookie.

If not provided, this will be set to the value of http.SameSiteDefaultMode, which is effectively
the same behavior as before this change.

However, this now allows a user to opt into using SameSiteLaxMode, SameSiteStrictMode,
or SameSiteNoneMode.

## Motivation and Context

This change improves security of proxied services by preventing CSRF attacks.

See: See: https://www.owasp.org/index.php/SameSite

## How Has This Been Tested?

Unit tests have been updated to verify the additional field on the session cookie.

The SameSite cookie attribute has been verified in debug tools in chrome.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
