### PR TITLE
Remove existing Authorization header if PassAuthorization is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Breaking Changes
 
 ## Changes since v4.1.0
+- [#345](https://github.com/pusher/oauth2_proxy/pull/345) Remove existing Authorization header if PassAuthorization is false (@blang)
 - [#325](https://github.com/pusher/oauth2_proxy/pull/325) dist.sh: use sha256sum (@syscll)
 - [#179](https://github.com/pusher/oauth2_proxy/pull/179) Add Nextcloud provider (@Ramblurr)
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -912,7 +912,11 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 		} else {
 			req.Header.Del("Authorization")
 		}
+	} else {
+		// Not PassAuthorization also removes previously passed authorization
+		req.Header.Del("Authorization")
 	}
+
 	if p.SetAuthorization {
 		if session.IDToken != "" {
 			rw.Header().Set("Authorization", fmt.Sprintf("Bearer %s", session.IDToken))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #344 
<!--- Describe your changes in detail -->

## Motivation and Context

Detailed description in issue https://github.com/pusher/oauth2_proxy/issues/344
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tests added in oauthproxy_test.go. 
It tests if it removes an existing Authorization header if `-pass-authorization-header=false`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
