### PR TITLE
Fix login page fragment handling after soft reload on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v5.0.0
 
+- [#353](https://github.com/pusher/oauth2_proxy/pull/353) Fix login page fragment handling after soft reload on Firefox (@ffdybuster)
+
 # v5.0.0
 
 ## Release Hightlights
@@ -34,7 +36,6 @@
 - [#179](https://github.com/pusher/oauth2_proxy/pull/179) Add Nextcloud provider (@Ramblurr)
 - [#280](https://github.com/pusher/oauth2_proxy/pull/280) whitelisted redirect domains: add support for whitelisting specific ports or allowing wildcard ports (@kamaln7)
 - [#351](https://github.com/pusher/oauth2_proxy/pull/351) Add DigitalOcean Auth provider (@kamaln7)
-- [#353](https://github.com/pusher/oauth2_proxy/pull/353) Fix login page fragment handling after soft reload on Firefox (@ffdybuster)
 
 # v4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [#179](https://github.com/pusher/oauth2_proxy/pull/179) Add Nextcloud provider (@Ramblurr)
 - [#280](https://github.com/pusher/oauth2_proxy/pull/280) whitelisted redirect domains: add support for whitelisting specific ports or allowing wildcard ports (@kamaln7)
 - [#351](https://github.com/pusher/oauth2_proxy/pull/351) Add DigitalOcean Auth provider (@kamaln7)
+- [#353](https://github.com/pusher/oauth2_proxy/pull/353) Fix login page fragment handling after soft reload on Firefox (@ffdybuster)
 
 # v4.1.0
 

--- a/templates.go
+++ b/templates.go
@@ -135,8 +135,10 @@ func getTemplates() *template.Template {
 			(function() {
 				var inputs = document.getElementsByName('rd');
 				for (var i = 0; i < inputs.length; i++) {
+					// Add hash, but make sure it is only added once
 					var idx = inputs[i].value.indexOf('#');
 					if (idx >= 0) {
+						// Remove existing hash from URL
 						inputs[i].value = inputs[i].value.substr(0, idx);
 					}
 					inputs[i].value += window.location.hash;

--- a/templates.go
+++ b/templates.go
@@ -135,6 +135,10 @@ func getTemplates() *template.Template {
 			(function() {
 				var inputs = document.getElementsByName('rd');
 				for (var i = 0; i < inputs.length; i++) {
+					var idx = inputs[i].value.indexOf('#');
+					if (idx >= 0) {
+						inputs[i].value = inputs[i].value.substr(0, idx);
+					}
 					inputs[i].value += window.location.hash;
 				}
 			})();


### PR DESCRIPTION
## Description

Fixes #352.

## Motivation and Context

Soft reloads on Firefox screw up the redirect link on the sign in page; see #352 for details.

## How Has This Been Tested?

I've downloaded the generated sign in page, manually applied the change from this PR, opened it in Firefox and tested it there (with the developers tools).

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
