### PR TITLE
Fix linting error about const

### DIFF
--- a/providers/auth_test.go
+++ b/providers/auth_test.go
@@ -1,0 +1,23 @@
+package providers
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+)
+
+var authorizedAccessToken = "imaginary_access_token"
+
+func CreateAuthorizedSession() *sessions.SessionState {
+	return &sessions.SessionState{AccessToken: authorizedAccessToken}
+}
+
+func IsAuthorizedInHeader(reqHeader http.Header) bool {
+	return reqHeader.Get("Authorization") == fmt.Sprintf("Bearer %s", authorizedAccessToken)
+}
+
+func IsAuthorizedInURL(reqURL *url.URL) bool {
+	return reqURL.Query().Get("access_token") == authorizedAccessToken
+}

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -118,7 +117,7 @@ func testAzureBackend(payload string) *httptest.Server {
 			} else if r.Method == "POST" && r.Body != nil {
 				w.WriteHeader(200)
 				w.Write([]byte(payload))
-			} else if r.Header.Get("Authorization") != "Bearer imaginary_access_token" {
+			} else if !IsAuthorizedInHeader(r.Header) {
 				w.WriteHeader(403)
 			} else {
 				w.WriteHeader(200)
@@ -134,7 +133,7 @@ func TestAzureProviderGetEmailAddress(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testAzureProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "user@windows.net", email)
@@ -147,7 +146,7 @@ func TestAzureProviderGetEmailAddressMailNull(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testAzureProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "user@windows.net", email)
@@ -160,7 +159,7 @@ func TestAzureProviderGetEmailAddressGetUserPrincipalName(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testAzureProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "user@windows.net", email)
@@ -173,7 +172,7 @@ func TestAzureProviderGetEmailAddressFailToGetEmailAddress(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testAzureProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, "type assertion to string failed", err.Error())
 	assert.Equal(t, "", email)
@@ -186,7 +185,7 @@ func TestAzureProviderGetEmailAddressEmptyUserPrincipalName(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testAzureProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "", email)
@@ -199,7 +198,7 @@ func TestAzureProviderGetEmailAddressIncorrectOtherMails(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testAzureProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, "type assertion to string failed", err.Error())
 	assert.Equal(t, "", email)

--- a/providers/bitbucket_test.go
+++ b/providers/bitbucket_test.go
@@ -51,7 +51,7 @@ func testBitbucketBackend(payload string) *httptest.Server {
 			if !paths[url.Path] {
 				log.Printf("%s not in %+v\n", url.Path, paths)
 				w.WriteHeader(404)
-			} else if r.URL.Query().Get("access_token") != "imaginary_access_token" {
+			} else if !IsAuthorizedInURL(r.URL) {
 				w.WriteHeader(403)
 			} else {
 				w.WriteHeader(200)
@@ -119,7 +119,7 @@ func TestBitbucketProviderGetEmailAddress(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testBitbucketProvider(bURL.Host, "", "")
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
@@ -132,7 +132,7 @@ func TestBitbucketProviderGetEmailAddressAndGroup(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testBitbucketProvider(bURL.Host, "bioinformatics", "")
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
@@ -163,7 +163,7 @@ func TestBitbucketProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) 
 	bURL, _ := url.Parse(b.URL)
 	p := testBitbucketProvider(bURL.Host, "", "")
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, "", email)
 	assert.Equal(t, nil, err)

--- a/providers/digitalocean_test.go
+++ b/providers/digitalocean_test.go
@@ -34,7 +34,7 @@ func testDigitalOceanBackend(payload string) *httptest.Server {
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != path {
 				w.WriteHeader(404)
-			} else if r.Header.Get("Authorization") != "Bearer imaginary_access_token" {
+			} else if !IsAuthorizedInHeader(r.Header) {
 				w.WriteHeader(403)
 			} else {
 				w.WriteHeader(200)
@@ -98,7 +98,7 @@ func TestDigitalOceanProviderGetEmailAddress(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testDigitalOceanProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "user@example.com", email)
@@ -127,7 +127,7 @@ func TestDigitalOceanProviderGetEmailAddressEmailNotPresentInPayload(t *testing.
 	bURL, _ := url.Parse(b.URL)
 	p := testDigitalOceanProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, "", email)

--- a/providers/github_test.go
+++ b/providers/github_test.go
@@ -104,7 +104,7 @@ func TestGitHubProviderGetEmailAddress(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testGitHubProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
@@ -117,7 +117,7 @@ func TestGitHubProviderGetEmailAddressNotVerified(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testGitHubProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Empty(t, "", email)
@@ -135,7 +135,7 @@ func TestGitHubProviderGetEmailAddressWithOrg(t *testing.T) {
 	p := testGitHubProvider(bURL.Host)
 	p.Org = "testorg1"
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
@@ -166,7 +166,7 @@ func TestGitHubProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testGitHubProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, "", email)
@@ -179,7 +179,7 @@ func TestGitHubProviderGetUserName(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testGitHubProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetUserName(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "mbland", email)

--- a/providers/keycloak_test.go
+++ b/providers/keycloak_test.go
@@ -10,9 +10,6 @@ import (
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
 )
 
-const imaginaryAccessToken = "imaginary_access_token"
-const bearerAccessToken = "Bearer " + imaginaryAccessToken
-
 func testKeycloakProvider(hostname, group string) *KeycloakProvider {
 	p := NewKeycloakProvider(
 		&ProviderData{
@@ -44,7 +41,7 @@ func testKeycloakBackend(payload string) *httptest.Server {
 			url := r.URL
 			if url.Path != path {
 				w.WriteHeader(404)
-			} else if r.Header.Get("Authorization") != bearerAccessToken {
+			} else if !IsAuthorizedInHeader(r.Header) {
 				w.WriteHeader(403)
 			} else {
 				w.WriteHeader(200)
@@ -100,7 +97,7 @@ func TestKeycloakProviderGetEmailAddress(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testKeycloakProvider(bURL.Host, "")
 
-	session := &sessions.SessionState{AccessToken: imaginaryAccessToken}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
@@ -113,7 +110,7 @@ func TestKeycloakProviderGetEmailAddressAndGroup(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testKeycloakProvider(bURL.Host, "test-grp1")
 
-	session := &sessions.SessionState{AccessToken: imaginaryAccessToken}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
@@ -144,7 +141,7 @@ func TestKeycloakProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testKeycloakProvider(bURL.Host, "")
 
-	session := &sessions.SessionState{AccessToken: imaginaryAccessToken}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, "", email)

--- a/providers/linkedin_test.go
+++ b/providers/linkedin_test.go
@@ -34,7 +34,7 @@ func testLinkedInBackend(payload string) *httptest.Server {
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != path {
 				w.WriteHeader(404)
-			} else if r.Header.Get("Authorization") != "Bearer imaginary_access_token" {
+			} else if !IsAuthorizedInHeader(r.Header) {
 				w.WriteHeader(403)
 			} else {
 				w.WriteHeader(200)
@@ -98,7 +98,7 @@ func TestLinkedInProviderGetEmailAddress(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testLinkedInProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "user@linkedin.com", email)
@@ -127,7 +127,7 @@ func TestLinkedInProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
 	bURL, _ := url.Parse(b.URL)
 	p := testLinkedInProvider(bURL.Host)
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, "", email)

--- a/providers/nextcloud_test.go
+++ b/providers/nextcloud_test.go
@@ -39,7 +39,7 @@ func testNextcloudBackend(payload string) *httptest.Server {
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != path || r.URL.RawQuery != query {
 				w.WriteHeader(404)
-			} else if r.Header.Get("Authorization") != "Bearer imaginary_access_token_nextcloud" {
+			} else if !IsAuthorizedInHeader(r.Header) {
 				w.WriteHeader(403)
 			} else {
 				w.WriteHeader(200)
@@ -96,7 +96,7 @@ func TestNextcloudProviderGetEmailAddress(t *testing.T) {
 	p.ValidateURL.Path = userPath
 	p.ValidateURL.RawQuery = formatJSON
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token_nextcloud"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "michael.bland@gsa.gov", email)
@@ -131,7 +131,7 @@ func TestNextcloudProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) 
 	p.ValidateURL.Path = userPath
 	p.ValidateURL.RawQuery = formatJSON
 
-	session := &sessions.SessionState{AccessToken: "imaginary_access_token_nextcloud"}
+	session := CreateAuthorizedSession()
 	email, err := p.GetEmailAddress(session)
 	assert.NotEqual(t, nil, err)
 	assert.Equal(t, "", email)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Small linting issue

<!--- Describe your changes in detail -->
Linting stage said `providers/azure_test.go:121:47: string `Bearer imaginary_access_token` has 3 occurrences, make it a constant (goconst)`

## Motivation and Context

I want to create another PR, but linting is failing

## How Has This Been Tested?

run
```
make test
```

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ x] I have created a feature (non-master) branch for my PR.
