### PR TITLE
Disable cgo on release builds

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -27,10 +27,10 @@ for ARCH in "${ARCHS[@]}"; do
 
 	# Create architecture specific binaries
 	if [[ ${GO_ARCH} == "armv6" ]]; then
-		GO111MODULE=on GOOS=${GO_OS} GOARCH=arm GOARM=6 go build -ldflags="-X main.VERSION=${VERSION}" \
+		GO111MODULE=on GOOS=${GO_OS} GOARCH=arm GOARM=6 CGO_ENABLED=0 go build -ldflags="-X main.VERSION=${VERSION}" \
 			-o release/${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}/${BINARY} github.com/pusher/oauth2_proxy
 	else
-		GO111MODULE=on GOOS=${GO_OS} GOARCH=${GO_ARCH} go build -ldflags="-X main.VERSION=${VERSION}" \
+		GO111MODULE=on GOOS=${GO_OS} GOARCH=${GO_ARCH} CGO_ENABLED=0 go build -ldflags="-X main.VERSION=${VERSION}" \
 			-o release/${BINARY}-${VERSION}.${ARCH}.${GO_VERSION}/${BINARY} github.com/pusher/oauth2_proxy
 	fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cgo tries to link against libc which isn't present in musl based distributions (such as Alpine Linux).

## Motivation and Context

https://github.com/pusher/oauth2_proxy/issues/329

## How Has This Been Tested?

-  `make release`
- `readelf -l release/oauth2_proxy-v4.1.0-37-gd9362d3-dirty.linux-amd64.go1.13.1/oauth2_proxy | grep "program interpreter"`
- `docker run -it --rm -v $PWD:/work -w /work alpine ./release/oauth2_proxy-v4.1.0-37-gd9362d3-dirty.linux-amd64.go1.13.1/oauth2_proxy --help`

I don't have a non Linux machine to test this on but I don't see why this would be broken on any other arch/os. The v4.0.0 release used to disable cgo until the `dist.sh` rewrite in https://github.com/pusher/oauth2_proxy/pull/302 which I think inadvertently reintroduced it.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
