### PR TITLE
GitHub Provider - Fallback to secondary verified email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Changes since v5.0.0
 
+- [#372](https://github.com/pusher/oauth2_proxy/pull/372) Allow fallback to secondary verified email address in GitHub provider (@dmnemec)
+
 # v5.0.0
 
 ## Release Hightlights

--- a/providers/github.go
+++ b/providers/github.go
@@ -305,13 +305,17 @@ func (p *GitHubProvider) GetEmailAddress(s *sessions.SessionState) (string, erro
 		return "", fmt.Errorf("%s unmarshaling %s", err, body)
 	}
 
+	returnEmail := ""
 	for _, email := range emails {
-		if email.Primary && email.Verified {
-			return email.Email, nil
+		if email.Verified {
+			returnEmail = email.Email
+			if email.Primary {
+				return returnEmail, nil
+			}
 		}
 	}
 
-	return "", nil
+	return returnEmail, nil
 }
 
 // GetUserName returns the Account user name


### PR DESCRIPTION
## References
Closes https://github.com/pusher/oauth2_proxy/issues/371

## Expected Behavior

We noticed after upgrading that some of our users could no longer login. We found that if the primary email is not verified, it would reject the request. Since many of our users either don't use their work email as their primary, a lot of them have a verified email, but not as their primary.

## Difference Current Behavior

Allow auth to continue with any verified email.

## Possible Solution

First, check that the primary email is verified and use that. If not, search for a secondary verified email. If none are found, _then_ return a blank email instead. 

## Context

As stated earlier, some of our users don't have primary emails verified but have secondary verified emails. As we onboard new people, we will continue to run into this problem in the future.
