### PR TITLE
Add sign_out endpoint to endpoint documentation page

### DIFF
--- a/docs/5_endpoints.md
+++ b/docs/5_endpoints.md
@@ -12,6 +12,7 @@ OAuth2 Proxy responds directly to the following endpoints. All other endpoints w
 - /robots.txt - returns a 200 OK response that disallows all User-agents from all paths; see [robotstxt.org](http://www.robotstxt.org/) for more info
 - /ping - returns a 200 OK response, which is intended for use with health checks
 - /oauth2/sign_in - the login page, which also doubles as a sign out page (it clears cookies)
+- /oauth2/sign_out - this URL is used to clear the session cookie
 - /oauth2/start - a URL that will redirect to start the OAuth cycle
 - /oauth2/callback - the URL used at the end of the OAuth cycle. The oauth app will be configured with this as the callback url.
 - /oauth2/userinfo - the URL is used to return user's email from the session in JSON format.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add sign_out endpoint to endpoint documentation page.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unlike other endpoints, sign_out is not currently listed on https://pusher.github.io/oauth2_proxy/endpoints.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran jekyll build.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
