### PR TITLE
Implement ValidateSessionState for GitHubProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Changes since v5.0.0
 
+- [#385](https://github.com/pusher/oauth2_proxy/pull/385) Use the `Authorization` header instead of `access_token` for refreshing GitHub Provider sessions (@ibuclaw)
 - [#335](https://github.com/pusher/oauth2_proxy/pull/335) OIDC Provider support for empty id_tokens in the access token refresh response (@howzat)
 - [#363](https://github.com/pusher/oauth2_proxy/pull/363) Extension of Redis Session Store to Support Redis Cluster (@yan-dblinf)
 - [#353](https://github.com/pusher/oauth2_proxy/pull/353) Fix login page fragment handling after soft reload on Firefox (@ffdybuster)


### PR DESCRIPTION
Refactors the setting of the Authorization header into getGitHubHeader.

Refs #382 

@JoelSpeed - at the risk of doing something you are already looking at, this change is untested, but _looks_ like it should fix the referenced problem.