### PR TITLE
Use OAuthProxy.GetRedirect in /sign_in, honoring the 'rd' query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Release Hightlights
 
 ## Important Notes
-- [#335] The session expiry for the OIDC provider is now taken from the Token Response (expires_in) rather than from the id_token (exp) 
+- [#335] The session expiry for the OIDC provider is now taken from the Token Response (expires_in) rather than from the id_token (exp)
 
 ## Breaking Changes
 
@@ -16,6 +16,7 @@
 - [#363](https://github.com/pusher/oauth2_proxy/pull/363) Extension of Redis Session Store to Support Redis Cluster (@yan-dblinf)
 - [#353](https://github.com/pusher/oauth2_proxy/pull/353) Fix login page fragment handling after soft reload on Firefox (@ffdybuster)
 - [#355](https://github.com/pusher/oauth2_proxy/pull/355) Add Client Secret File support for providers that rotate client secret via file system (@pasha-r)
+- [#405](https://github.com/pusher/oauth2_proxy/pull/405) The `/sign_in` page now honors the `rd` query parameter, fixing the redirect after a successful authentication (@ti-mo)
 
 # v5.0.0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

@JoelSpeed asked for help fixing https://github.com/pusher/oauth2_proxy/issues/328 after concluding the `/sign_in` page did not honor the `rd` query parameter. `/start` and `/sign_in` now use largely the same logic to determine the redirection target based on either the `rd` query param or the `X-Auth-Request-Redirect` request header.

## Description

This is a small change that introduces the `OAuthProxy.GetRedirect()` function in the `/sign_in` http handler. Prior to this, only the `X-Auth-Request-Redirect` header was  honored, and the `rd` query parameter would only work with `/start`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This addresses https://github.com/pusher/oauth2_proxy/issues/328.

## How Has This Been Tested?

Setting the `rd` query parameter now correctly renders the hidden `rd` form field.
```
~ curl -s 'https://oauth2.example.com/oauth2/sign_in?rd=/foo' | grep '"rd"'
	<input type="hidden" name="rd" value="/foo">
```
Before the change, this parameter would be ignored, redirecting to the current URI instead:
```
~ curl -s 'https://oauth2.example.com/oauth2/sign_in?rd=/foo' | grep '"rd"'
	<input type="hidden" name="rd" value="/oauth2/sign_in?rd=/foo">
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.

:point_up: Not sure why feature branches are a requirement, this is a PR from a fork.

Let me know what you think!
