### PR TITLE
Allow basic auth to be configured on the upstream

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -113,6 +113,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-tls-cert-file` | string | path to certificate file | |
 | `-tls-key-file` | string | path to private key file | |
 | `-upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |
+| `-upstream-authorization-header` | string | The Authorization header that needs to be set towards the upstream. Useful in for example accessing services with a shared secret like Basic Auth | |
 | `-validate-url` | string | Access token validation endpoint | |
 | `-version` | n/a | print version string | |
 | `-whitelist-domain` | string \| list | allowed domains for redirection after authentication. Prefix domain with a `.` to allow subdomains (eg `.example.com`) | |

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	flagSet.String("tls-cert-file", "", "path to certificate file")
 	flagSet.String("tls-key-file", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
+	flagSet.String("upstream-authorization-header", "", "the content of the authorization header that needs to be set towards the upstream resource")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Var(&upstreams, "upstream", "the http url(s) of the upstream endpoint, file:// paths for static files or static://<status_code> for static response. Routing is based on the path")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -80,32 +80,33 @@ type OAuthProxy struct {
 	AuthOnlyPath      string
 	UserInfoPath      string
 
-	redirectURL          *url.URL // the url to receive requests at
-	whitelistDomains     []string
-	provider             providers.Provider
-	providerNameOverride string
-	sessionStore         sessionsapi.SessionStore
-	ProxyPrefix          string
-	SignInMessage        string
-	HtpasswdFile         *HtpasswdFile
-	DisplayHtpasswdForm  bool
-	serveMux             http.Handler
-	SetXAuthRequest      bool
-	PassBasicAuth        bool
-	SkipProviderButton   bool
-	PassUserHeaders      bool
-	BasicAuthPassword    string
-	PassAccessToken      bool
-	SetAuthorization     bool
-	PassAuthorization    bool
-	skipAuthRegex        []string
-	skipAuthPreflight    bool
-	skipJwtBearerTokens  bool
-	jwtBearerVerifiers   []*oidc.IDTokenVerifier
-	compiledRegex        []*regexp.Regexp
-	templates            *template.Template
-	Banner               string
-	Footer               string
+	redirectURL                 *url.URL // the url to receive requests at
+	whitelistDomains            []string
+	provider                    providers.Provider
+	providerNameOverride        string
+	sessionStore                sessionsapi.SessionStore
+	ProxyPrefix                 string
+	SignInMessage               string
+	HtpasswdFile                *HtpasswdFile
+	DisplayHtpasswdForm         bool
+	serveMux                    http.Handler
+	SetXAuthRequest             bool
+	UpstreamAuthorizationHeader string
+	PassBasicAuth               bool
+	SkipProviderButton          bool
+	PassUserHeaders             bool
+	BasicAuthPassword           string
+	PassAccessToken             bool
+	SetAuthorization            bool
+	PassAuthorization           bool
+	skipAuthRegex               []string
+	skipAuthPreflight           bool
+	skipJwtBearerTokens         bool
+	jwtBearerVerifiers          []*oidc.IDTokenVerifier
+	compiledRegex               []*regexp.Regexp
+	templates                   *template.Template
+	Banner                      string
+	Footer                      string
 }
 
 // UpstreamProxy represents an upstream server to proxy to
@@ -285,29 +286,30 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 		UserInfoPath:      fmt.Sprintf("%s/userinfo", opts.ProxyPrefix),
 
-		ProxyPrefix:          opts.ProxyPrefix,
-		provider:             opts.provider,
-		providerNameOverride: opts.ProviderName,
-		sessionStore:         opts.sessionStore,
-		serveMux:             serveMux,
-		redirectURL:          redirectURL,
-		whitelistDomains:     opts.WhitelistDomains,
-		skipAuthRegex:        opts.SkipAuthRegex,
-		skipAuthPreflight:    opts.SkipAuthPreflight,
-		skipJwtBearerTokens:  opts.SkipJwtBearerTokens,
-		jwtBearerVerifiers:   opts.jwtBearerVerifiers,
-		compiledRegex:        opts.CompiledRegex,
-		SetXAuthRequest:      opts.SetXAuthRequest,
-		PassBasicAuth:        opts.PassBasicAuth,
-		PassUserHeaders:      opts.PassUserHeaders,
-		BasicAuthPassword:    opts.BasicAuthPassword,
-		PassAccessToken:      opts.PassAccessToken,
-		SetAuthorization:     opts.SetAuthorization,
-		PassAuthorization:    opts.PassAuthorization,
-		SkipProviderButton:   opts.SkipProviderButton,
-		templates:            loadTemplates(opts.CustomTemplatesDir),
-		Banner:               opts.Banner,
-		Footer:               opts.Footer,
+		ProxyPrefix:                 opts.ProxyPrefix,
+		provider:                    opts.provider,
+		providerNameOverride:        opts.ProviderName,
+		sessionStore:                opts.sessionStore,
+		serveMux:                    serveMux,
+		redirectURL:                 redirectURL,
+		whitelistDomains:            opts.WhitelistDomains,
+		skipAuthRegex:               opts.SkipAuthRegex,
+		skipAuthPreflight:           opts.SkipAuthPreflight,
+		skipJwtBearerTokens:         opts.SkipJwtBearerTokens,
+		jwtBearerVerifiers:          opts.jwtBearerVerifiers,
+		compiledRegex:               opts.CompiledRegex,
+		SetXAuthRequest:             opts.SetXAuthRequest,
+		PassBasicAuth:               opts.PassBasicAuth,
+		PassUserHeaders:             opts.PassUserHeaders,
+		BasicAuthPassword:           opts.BasicAuthPassword,
+		PassAccessToken:             opts.PassAccessToken,
+		SetAuthorization:            opts.SetAuthorization,
+		UpstreamAuthorizationHeader: opts.UpstreamAuthorizationHeader,
+		PassAuthorization:           opts.PassAuthorization,
+		SkipProviderButton:          opts.SkipProviderButton,
+		templates:                   loadTemplates(opts.CustomTemplatesDir),
+		Banner:                      opts.Banner,
+		Footer:                      opts.Footer,
 	}
 }
 
@@ -976,6 +978,11 @@ func (p *OAuthProxy) addHeadersForProxying(rw http.ResponseWriter, req *http.Req
 		} else {
 			rw.Header().Del("Authorization")
 		}
+	}
+
+	if len(p.UpstreamAuthorizationHeader) > 0 {
+		logger.Printf("setting basic auth")
+		req.Header["Authorization"] = []string{fmt.Sprintf("%s", p.UpstreamAuthorizationHeader)}
 	}
 
 	if session.Email == "" {

--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -1034,7 +1034,6 @@ func TestAuthSkippedForPreflightRequests(t *testing.T) {
 	opts.provider = NewTestProvider(upstreamURL, "")
 
 	proxy := NewOAuthProxy(opts, func(string) bool { return false })
-	logger.Printf("%+v", proxy)
 	rw := httptest.NewRecorder()
 	req, _ := http.NewRequest("OPTIONS", "/preflight-request", nil)
 	proxy.ServeHTTP(rw, req)
@@ -1443,7 +1442,6 @@ func TestJwtUnauthorizedOnGroupValidationFailure(t *testing.T) {
 	}
 	test.proxy.ServeHTTP(test.rw, test.req)
 	if test.rw.Code != http.StatusUnauthorized {
-		logger.Printf("%v", test.rw.Code)
 		t.Fatalf("expected 401 got %d", test.rw.Code)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -496,9 +496,6 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 			}
 		}
 	}
-	//case *providers.DropsolidProvider:
-	//	p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
-	//}
 	return msgs
 }
 

--- a/options.go
+++ b/options.go
@@ -495,9 +495,9 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 				p.JWTKey = signKey
 			}
 		}
-	case *providers.DropsolidProvider:
-		p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
-	}
+	//case *providers.DropsolidProvider:
+	//	p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
+	//}
 	return msgs
 }
 

--- a/options.go
+++ b/options.go
@@ -412,6 +412,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 	p.ProfileURL, msgs = parseURL(o.ProfileURL, "profile", msgs)
 	p.ValidateURL, msgs = parseURL(o.ValidateURL, "validate", msgs)
 	p.ProtectedResource, msgs = parseURL(o.ProtectedResource, "resource", msgs)
+	p.JwtBearerVerifiers = o.jwtBearerVerifiers
 
 	o.provider = providers.New(o.Provider, p)
 	switch p := o.provider.(type) {
@@ -494,6 +495,8 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 				p.JWTKey = signKey
 			}
 		}
+	case *providers.DropsolidProvider:
+		p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
 	}
 	return msgs
 }

--- a/options.go
+++ b/options.go
@@ -82,6 +82,7 @@ type Options struct {
 	SSLUpstreamInsecureSkipVerify bool          `flag:"ssl-upstream-insecure-skip-verify" cfg:"ssl_upstream_insecure_skip_verify" env:"OAUTH2_PROXY_SSL_UPSTREAM_INSECURE_SKIP_VERIFY"`
 	SetXAuthRequest               bool          `flag:"set-xauthrequest" cfg:"set_xauthrequest" env:"OAUTH2_PROXY_SET_XAUTHREQUEST"`
 	SetAuthorization              bool          `flag:"set-authorization-header" cfg:"set_authorization_header" env:"OAUTH2_PROXY_SET_AUTHORIZATION_HEADER"`
+	UpstreamAuthorizationHeader   string        `flag:"upstream-authorization-header" cfg:"upstream_authorization_header" env:"OAUTH2_PROXY_UPSTREAM_AUTHORIZATION_HEADER"`
 	PassAuthorization             bool          `flag:"pass-authorization-header" cfg:"pass_authorization_header" env:"OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER"`
 	SkipAuthPreflight             bool          `flag:"skip-auth-preflight" cfg:"skip_auth_preflight" env:"OAUTH2_PROXY_SKIP_AUTH_PREFLIGHT"`
 	FlushInterval                 time.Duration `flag:"flush-interval" cfg:"flush_interval" env:"OAUTH2_PROXY_FLUSH_INTERVAL"`
@@ -168,6 +169,7 @@ func NewOptions() *Options {
 		PassAccessToken:                  false,
 		PassHostHeader:                   true,
 		SetAuthorization:                 false,
+		UpstreamAuthorizationHeader:      "",
 		PassAuthorization:                false,
 		ApprovalPrompt:                   "force",
 		InsecureOIDCAllowUnverifiedEmail: false,
@@ -541,8 +543,8 @@ func parseJwtIssuers(issuers []string, msgs []string) ([]jwtIssuer, []string) {
 // a verifier for that issuer.
 func newVerifierFromJwtIssuer(jwtIssuer jwtIssuer) (*oidc.IDTokenVerifier, error) {
 	config := &oidc.Config{
-		ClientID: jwtIssuer.audience,
-                SkipClientIDCheck: true,
+		ClientID:          jwtIssuer.audience,
+		SkipClientIDCheck: true,
 	}
 	// Try as an OpenID Connect Provider first
 	var verifier *oidc.IDTokenVerifier

--- a/options.go
+++ b/options.go
@@ -495,6 +495,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 				p.JWTKey = signKey
 			}
 		}
+	}
 	//case *providers.DropsolidProvider:
 	//	p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
 	//}

--- a/options.go
+++ b/options.go
@@ -542,6 +542,7 @@ func parseJwtIssuers(issuers []string, msgs []string) ([]jwtIssuer, []string) {
 func newVerifierFromJwtIssuer(jwtIssuer jwtIssuer) (*oidc.IDTokenVerifier, error) {
 	config := &oidc.Config{
 		ClientID: jwtIssuer.audience,
+                SkipClientIDCheck: true,
 	}
 	// Try as an OpenID Connect Provider first
 	var verifier *oidc.IDTokenVerifier

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -135,7 +135,6 @@ func (p *DropsolidProvider) GetEmailAddress(s *sessions.SessionState) (string, e
 
 // ValidateSessionState validates the AccessToken
 func (p *DropsolidProvider) ValidateSessionState(s *sessions.SessionState) bool {
-	logger.Printf("validating token")
 	return validateToken(p, s.AccessToken, getDropsolidHeader(s.AccessToken))
 }
 
@@ -146,7 +145,6 @@ func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.Sessio
 		err = errors.New("missing code")
 		return
 	}
-	logger.Printf("%v", "Got into the redeem")
 
 	params := url.Values{}
 	params.Add("redirect_uri", redirectURL)

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -1,23 +1,45 @@
 package providers
 
 import (
-	"errors"
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
+	"io/ioutil"
+	"encoding/json"
+    "crypto/rsa"
+	"time"
+	"errors"
+	"context"
 
+	//"gopkg.in/square/go-jose.v2"
+	//"github.com/coreos/go-oidc"
+	"github.com/dgrijalva/jwt-go"
+    "github.com/pusher/oauth2_proxy/pkg/logger"
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
-	"github.com/pusher/oauth2_proxy/pkg/requests"
 )
 
-// DigitalOceanProvider represents a DigitalOcean based Identity Provider
+// DropsolidProvider represents a Dropsolid Platform based Identity Provider
 type DropsolidProvider struct {
 	*ProviderData
+	JWTKey    *rsa.PrivateKey
+	PubJWKURL *url.URL
 }
 
-// NewDigitalOceanProvider initiates a new DigitalOceanProvider
+type dropsolidJwtClaims struct {
+	Scopes     []string   `json:"scopes"`
+	jwt.StandardClaims
+}
+
+type dropsolidUserInfo struct {
+	UserId        string   `json:"sub"`
+	Email         string   `json:"email"`
+}
+
+// NewDropsolidProvider initiates a new DropsolidProvider
 func NewDropsolidProvider(p *ProviderData) *DropsolidProvider {
 	p.ProviderName = "Dropsolid"
+
 	if p.LoginURL.String() == "" {
 		p.LoginURL = &url.URL{Scheme: "https",
 			Host: "platform.dropsolid.com",
@@ -36,8 +58,13 @@ func NewDropsolidProvider(p *ProviderData) *DropsolidProvider {
 			Path: "/oauth/user.info",
 		}
 	}
+
+	if p.ValidateURL.String() == "" {
+		p.ValidateURL = p.ProfileURL
+	}
+
 	if p.Scope == "" {
-		p.Scope = "openid"
+		p.Scope = "openid email"
 	}
 	return &DropsolidProvider{ProviderData: p}
 }
@@ -49,53 +76,319 @@ func getDropsolidHeader(accessToken string) http.Header {
 	return header
 }
 
-// GetUserName returns the Account user name
-func (p *DropsolidProvider) GetUserName(s *sessions.SessionState) (string, error) {
-	if s.AccessToken == "" {
-		return "", errors.New("missing access token")
-	}
 
+func (p *DropsolidProvider) getUserInfo(s *sessions.SessionState) (*dropsolidUserInfo, error) {
+	// Retrieve user info JSON
 	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("failed to create user info request: %v", err)
 	}
-	req.Header = getDropsolidHeader(s.AccessToken)
+	req.Header.Set("Authorization", "Bearer "+s.AccessToken)
 
-	json, err := requests.Request(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, fmt.Errorf("failed to perform user info request: %v", err)
+	}
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read user info response: %v", err)
 	}
 
-	userId, err := json.GetPath("sub").String()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("got %d during user info request: %s", resp.StatusCode, body)
+	}
 
-	return userId, nil
+	var userInfo dropsolidUserInfo
+	err = json.Unmarshal(body, &userInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse user info: %v", err)
+	}
+	// handle json did not match error
+    if userInfo.UserId == "" || userInfo.Email == "" {
+        return nil, fmt.Errorf("failed to parse user info: %v", err)
+    }
+
+	return &userInfo, nil
+}
+
+// GetUserName returns the Account user name
+func (p *DropsolidProvider) GetUserName(s *sessions.SessionState) (string, error) {
+	// Retrieve user info
+	userInfo, err := p.getUserInfo(s)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve user info: %v", err)
+	}
+
+	return userInfo.UserId, nil
 }
 
 
 // GetEmailAddress returns the Account email address
 func (p *DropsolidProvider) GetEmailAddress(s *sessions.SessionState) (string, error) {
-	if s.AccessToken == "" {
-		return "", errors.New("missing access token")
-	}
-	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
+	// Retrieve user info
+	userInfo, err := p.getUserInfo(s)
 	if err != nil {
-		return "", err
-	}
-	req.Header = getDropsolidHeader(s.AccessToken)
-
-	json, err := requests.Request(req)
-	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to retrieve user info: %v", err)
 	}
 
-	email, err := json.GetPath("email").String()
-	if err != nil {
-		return "", err
-	}
-	return email, nil
+	return userInfo.Email, nil
 }
 
 // ValidateSessionState validates the AccessToken
 func (p *DropsolidProvider) ValidateSessionState(s *sessions.SessionState) bool {
+	logger.Printf("validating token")
 	return validateToken(p, s.AccessToken, getDropsolidHeader(s.AccessToken))
+}
+
+// Redeem provides a Dropsolid implementation of the OAuth2 token redemption process
+// which also supports the refresh flow.
+func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.SessionState, err error) {
+	if code == "" {
+		err = errors.New("missing code")
+		return
+	}
+	logger.Printf("%v", "Got into the redeem")
+
+	params := url.Values{}
+	params.Add("redirect_uri", redirectURL)
+	params.Add("client_id", p.ClientID)
+	params.Add("client_secret", p.ClientSecret)
+	params.Add("code", code)
+	params.Add("grant_type", "authorization_code")
+
+	var req *http.Request
+	req, err = http.NewRequest("POST", p.RedeemURL.String(), bytes.NewBufferString(params.Encode()))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	var resp *http.Response
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		err = fmt.Errorf("got %d from %q %s", resp.StatusCode, p.RedeemURL.String(), body)
+		return
+	}
+
+	// blindly try json and x-www-form-urlencoded
+	var jsonResponse struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn int64 `json:"expires_in"`
+		TokenType string `json:"token_type"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	err = json.Unmarshal(body, &jsonResponse)
+
+	if err != nil {
+		return
+	}
+
+	// Validate the JWT Token
+	c, err := p.validateJwtTokenAndGetClaims(jsonResponse.AccessToken)
+	//token, err := jwt.ParseWithClaims(jsonResponse.AccessToken, &dropsolidJwtClaims{}, p.getPublicKeyFromJwtBearerVerfifier)
+	// If the JWT validation fails, something is really wrong. 
+	// Do not allow to continue.
+	if (err != nil) {
+		return
+	}
+	claims := c.(*dropsolidJwtClaims)
+	if (err != nil) {
+		return
+	}
+	// Check the expiration date in the JWT
+	// Decode the JWT token data.
+	//claims := token.Claims.(*dropsolidJwtClaims)
+	// Check if it needs a refresh based on the JWT expiry date
+	t := time.Unix(claims.ExpiresAt, 0)
+
+	if err == nil {
+		s = &sessions.SessionState{
+			AccessToken: jsonResponse.AccessToken,
+			RefreshToken: jsonResponse.RefreshToken,
+			CreatedAt:    time.Now(),
+			ExpiresOn:    t,
+		}
+		return
+	}
+
+	var v url.Values
+	v, err = url.ParseQuery(string(body))
+	if err != nil {
+		return
+	}
+	if a := v.Get("access_token"); a != "" {
+		s = &sessions.SessionState{AccessToken: a, CreatedAt: time.Now()}
+	} else {
+		err = fmt.Errorf("no access token found %s", body)
+	}
+	return
+}
+
+/*func (p *DropsolidProvider) getPublicKeyFromJwtBearerVerfifier(token *jwt.Token) (interface{}, error) {
+	// @Todo, refactor this to use the p.JwtBearerVerifiers data.
+	resp, myerr := http.Get(p.PubJWKURL.String())
+	if myerr != nil {
+		return nil, myerr
+	}
+	if resp.StatusCode != 200 {
+		myerr = fmt.Errorf("got %d from %q", resp.StatusCode, p.PubJWKURL.String())
+		return nil, myerr
+	}
+	body, myerr := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if myerr != nil {
+		return nil, myerr
+	}
+
+	var pubkeys jose.JSONWebKeySet
+	myerr = json.Unmarshal(body, &pubkeys)
+	if myerr != nil {
+		return nil, myerr
+	}
+	pubkey := pubkeys.Keys[0]
+	return pubkey.Key, nil
+}*/
+
+// RefreshSessionIfNeeded checks if the session has expired and uses the
+// RefreshToken to fetch a new ID token if required
+func (p *DropsolidProvider) RefreshSessionIfNeeded(s *sessions.SessionState) (bool, error) {
+	// do not refresh when there is no session, when the session is not expired or when the token is seen as valid.
+	// The session stays valid.
+	if s == nil || s.ExpiresOn.After(time.Now()) || s.RefreshToken == "" {
+		return false, nil
+	}
+
+	newToken, newRefreshToken, err := p.redeemRefreshToken(s.RefreshToken)
+	if err != nil {
+		return false, err
+	}
+
+	// Validate the JWT Token
+	c, err := p.validateJwtTokenAndGetClaims(newToken)
+	// If the JWT validation fails, something is really wrong. 
+	// Do not allow to continue.
+	if (err != nil) {
+		return false, err
+	}
+	claims := c.(*dropsolidJwtClaims)
+	if (err != nil) {
+		return false, err
+	}
+	// Check the expiration date in the JWT
+	// Decode the JWT token data.
+	t := time.Unix(claims.ExpiresAt, 0)
+	origExpiration := s.ExpiresOn
+	s.AccessToken = newToken
+	s.RefreshToken = newRefreshToken
+	s.ExpiresOn = t
+	logger.Printf("Refreshed access token %s (expired on %s)", s, origExpiration)
+
+	return true, nil
+}
+
+func (p *DropsolidProvider) redeemRefreshToken(refreshToken string) (newToken string, newRefreshToken string, err error) {
+	params := url.Values{}
+	params.Add("client_id", p.ClientID)
+	params.Add("client_secret", p.ClientSecret)
+	params.Add("refresh_token", refreshToken)
+	params.Add("grant_type", "refresh_token")
+	var req *http.Request
+	req, err = http.NewRequest("POST", p.RedeemURL.String(), bytes.NewBufferString(params.Encode()))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		err = fmt.Errorf("got %d from %q %s", resp.StatusCode, p.RedeemURL.String(), body)
+		return
+	}
+
+	var data struct {
+		AccessToken string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`		
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return
+	}
+	newToken = data.AccessToken
+	newRefreshToken = data.RefreshToken
+	// we ignore ExpiresIn in favor of the data in the JWT token.
+	return
+}
+
+func (p *DropsolidProvider) validateJwtTokenAndGetClaims(rawBearerToken string) (interface{}, error) {
+	ctx := context.Background()
+	for _, verifier := range p.JwtBearerVerifiers {
+		bearerToken, err := verifier.Verify(ctx, rawBearerToken)
+
+		if err != nil {
+			logger.Printf("failed to verify bearer token: %v", err)
+			continue
+		}
+
+		var claims dropsolidJwtClaims
+		if err := bearerToken.Claims(&claims); err != nil {
+			return nil, fmt.Errorf("failed to parse bearer token claims: %v", err)
+		}
+
+		return claims, nil
+	}
+	return nil, fmt.Errorf("failed to process the raw bearer token or there were no bearer verifiers present")
+}
+
+// GetJwtSession loads a session based on a JWT token in the authorization header.
+func (p *DropsolidProvider) GetJwtSession(rawBearerToken string) (*sessions.SessionState, error) {
+	// Validate the JWT Token
+	c, err := p.validateJwtTokenAndGetClaims(rawBearerToken)
+	if (err != nil) {
+		return nil, err
+	}
+
+	claims := c.(*dropsolidJwtClaims)
+	if (err != nil) {
+		return nil, err
+	}
+
+	// Check the expiration date in the JWT
+	t := time.Unix(claims.ExpiresAt, 0)
+	session := &sessions.SessionState{
+		AccessToken:  rawBearerToken,
+		CreatedAt:    time.Now(),
+		ExpiresOn:    t,
+		User:         claims.Subject,
+	}
+
+	// Get email address
+	email, err := p.GetEmailAddress(session)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve email")
+	}
+	session.Email = email
+	return session, nil
 }

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -203,13 +203,13 @@ func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.Sessio
 	if (err != nil) {
 		return
 	}
-	claims := c.(*dropsolidJwtClaims)
+	claims := c.(dropsolidJwtClaims)
 	if (err != nil) {
 		return
 	}
 	// Check the expiration date in the JWT
 	// Decode the JWT token data.
-	//claims := token.Claims.(*dropsolidJwtClaims)
+	//claims := token.Claims.(dropsolidJwtClaims)
 	// Check if it needs a refresh based on the JWT expiry date
 	t := time.Unix(claims.ExpiresAt, 0)
 
@@ -370,7 +370,7 @@ func (p *DropsolidProvider) GetJwtSession(rawBearerToken string) (*sessions.Sess
 		return nil, err
 	}
 
-	claims := c.(*dropsolidJwtClaims)
+	claims := c.(dropsolidJwtClaims)
 	if (err != nil) {
 		return nil, err
 	}

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -1,0 +1,101 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"github.com/pusher/oauth2_proxy/pkg/requests"
+)
+
+// DigitalOceanProvider represents a DigitalOcean based Identity Provider
+type DropsolidProvider struct {
+	*ProviderData
+}
+
+// NewDigitalOceanProvider initiates a new DigitalOceanProvider
+func NewDropsolidProvider(p *ProviderData) *DropsolidProvider {
+	p.ProviderName = "Dropsolid"
+	if p.LoginURL.String() == "" {
+		p.LoginURL = &url.URL{Scheme: "https",
+			Host: "platform.dropsolid.com",
+			Path: "/oauth/authorize",
+		}
+	}
+	if p.RedeemURL.String() == "" {
+		p.RedeemURL = &url.URL{Scheme: "https",
+			Host: "platform.dropsolid.com",
+			Path: "/oauth/token",
+		}
+	}
+	if p.ProfileURL.String() == "" {
+		p.ProfileURL = &url.URL{Scheme: "https",
+			Host: "platform.dropsolid.com",
+			Path: "/oauth/user.info",
+		}
+	}
+	if p.Scope == "" {
+		p.Scope = "openid"
+	}
+	return &DropsolidProvider{ProviderData: p}
+}
+
+func getDropsolidHeader(accessToken string) http.Header {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	return header
+}
+
+// GetUserName returns the Account user name
+func (p *DropsolidProvider) GetUserName(s *sessions.SessionState) (string, error) {
+	if s.AccessToken == "" {
+		return "", errors.New("missing access token")
+	}
+
+	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header = getDropsolidHeader(s.AccessToken)
+
+	json, err := requests.Request(req)
+	if err != nil {
+		return "", err
+	}
+
+	userId, err := json.GetPath("sub").String()
+
+	return userId, nil
+}
+
+
+// GetEmailAddress returns the Account email address
+func (p *DropsolidProvider) GetEmailAddress(s *sessions.SessionState) (string, error) {
+	if s.AccessToken == "" {
+		return "", errors.New("missing access token")
+	}
+	req, err := http.NewRequest("GET", p.ProfileURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header = getDropsolidHeader(s.AccessToken)
+
+	json, err := requests.Request(req)
+	if err != nil {
+		return "", err
+	}
+
+	email, err := json.GetPath("email").String()
+	if err != nil {
+		return "", err
+	}
+	return email, nil
+}
+
+// ValidateSessionState validates the AccessToken
+func (p *DropsolidProvider) ValidateSessionState(s *sessions.SessionState) bool {
+	return validateToken(p, s.AccessToken, getDropsolidHeader(s.AccessToken))
+}

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -12,8 +12,6 @@ import (
 	"errors"
 	"context"
 
-	//"gopkg.in/square/go-jose.v2"
-	//"github.com/coreos/go-oidc"
 	"github.com/dgrijalva/jwt-go"
     "github.com/pusher/oauth2_proxy/pkg/logger"
 	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -23,7 +23,6 @@ import (
 type DropsolidProvider struct {
 	*ProviderData
 	JWTKey    *rsa.PrivateKey
-//	PubJWKURL *url.URL
 }
 
 type dropsolidJwtClaims struct {

--- a/providers/dropsolid.go
+++ b/providers/dropsolid.go
@@ -23,7 +23,7 @@ import (
 type DropsolidProvider struct {
 	*ProviderData
 	JWTKey    *rsa.PrivateKey
-	PubJWKURL *url.URL
+//	PubJWKURL *url.URL
 }
 
 type dropsolidJwtClaims struct {
@@ -235,31 +235,6 @@ func (p *DropsolidProvider) Redeem(redirectURL, code string) (s *sessions.Sessio
 	}
 	return
 }
-
-/*func (p *DropsolidProvider) getPublicKeyFromJwtBearerVerfifier(token *jwt.Token) (interface{}, error) {
-	// @Todo, refactor this to use the p.JwtBearerVerifiers data.
-	resp, myerr := http.Get(p.PubJWKURL.String())
-	if myerr != nil {
-		return nil, myerr
-	}
-	if resp.StatusCode != 200 {
-		myerr = fmt.Errorf("got %d from %q", resp.StatusCode, p.PubJWKURL.String())
-		return nil, myerr
-	}
-	body, myerr := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if myerr != nil {
-		return nil, myerr
-	}
-
-	var pubkeys jose.JSONWebKeySet
-	myerr = json.Unmarshal(body, &pubkeys)
-	if myerr != nil {
-		return nil, myerr
-	}
-	pubkey := pubkeys.Keys[0]
-	return pubkey.Key, nil
-}*/
 
 // RefreshSessionIfNeeded checks if the session has expired and uses the
 // RefreshToken to fetch a new ID token if required

--- a/providers/dropsolid_test.go
+++ b/providers/dropsolid_test.go
@@ -28,7 +28,7 @@ func testDropsolidProvider(hostname string) *DropsolidProvider {
 }
 
 func testDropsolidBackend(payload string) *httptest.Server {
-	path := "/v2/account"
+	path := "/oauth/user.info"
 
 	return httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -47,15 +47,15 @@ func TestDropsolidProviderDefaults(t *testing.T) {
 	p := testDropsolidProvider("")
 	assert.NotEqual(t, nil, p)
 	assert.Equal(t, "Dropsolid", p.Data().ProviderName)
-	assert.Equal(t, "https://cloud.Dropsolid.com/v1/oauth/authorize",
+	assert.Equal(t, "https://platform.dropsolid.com/oauth/authorize",
 		p.Data().LoginURL.String())
-	assert.Equal(t, "https://cloud.Dropsolid.com/v1/oauth/token",
+	assert.Equal(t, "https://platform.dropsolid.com/oauth/token",
 		p.Data().RedeemURL.String())
-	assert.Equal(t, "https://api.Dropsolid.com/v2/account",
+	assert.Equal(t, "https://platform.dropsolid.com/oauth/user.info",
 		p.Data().ProfileURL.String())
-	assert.Equal(t, "https://api.Dropsolid.com/v2/account",
+	assert.Equal(t, "https://platform.dropsolid.com/oauth/user.info",
 		p.Data().ValidateURL.String())
-	assert.Equal(t, "read", p.Data().Scope)
+	assert.Equal(t, "openid email", p.Data().Scope)
 }
 
 func TestDropsolidProviderOverrides(t *testing.T) {
@@ -92,7 +92,7 @@ func TestDropsolidProviderOverrides(t *testing.T) {
 }
 
 func TestDropsolidProviderGetEmailAddress(t *testing.T) {
-	b := testDropsolidBackend(`{"account": {"email": "user@example.com"}}`)
+	b := testDropsolidBackend(`{"sub": "23", "email":"user@example.com"}`)
 	defer b.Close()
 
 	bURL, _ := url.Parse(b.URL)

--- a/providers/dropsolid_test.go
+++ b/providers/dropsolid_test.go
@@ -1,0 +1,134 @@
+package providers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"github.com/stretchr/testify/assert"
+)
+
+func testDropsolidProvider(hostname string) *DropsolidProvider {
+	p := NewDropsolidProvider(
+		&ProviderData{
+			ProviderName: "",
+			LoginURL:     &url.URL{},
+			RedeemURL:    &url.URL{},
+			ProfileURL:   &url.URL{},
+			ValidateURL:  &url.URL{},
+			Scope:        ""})
+	if hostname != "" {
+		updateURL(p.Data().LoginURL, hostname)
+		updateURL(p.Data().RedeemURL, hostname)
+		updateURL(p.Data().ProfileURL, hostname)
+	}
+	return p
+}
+
+func testDropsolidBackend(payload string) *httptest.Server {
+	path := "/v2/account"
+
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != path {
+				w.WriteHeader(404)
+			} else if r.Header.Get("Authorization") != "Bearer imaginary_access_token" {
+				w.WriteHeader(403)
+			} else {
+				w.WriteHeader(200)
+				w.Write([]byte(payload))
+			}
+		}))
+}
+
+func TestDropsolidProviderDefaults(t *testing.T) {
+	p := testDropsolidProvider("")
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Dropsolid", p.Data().ProviderName)
+	assert.Equal(t, "https://cloud.Dropsolid.com/v1/oauth/authorize",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://cloud.Dropsolid.com/v1/oauth/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://api.Dropsolid.com/v2/account",
+		p.Data().ProfileURL.String())
+	assert.Equal(t, "https://api.Dropsolid.com/v2/account",
+		p.Data().ValidateURL.String())
+	assert.Equal(t, "read", p.Data().Scope)
+}
+
+func TestDropsolidProviderOverrides(t *testing.T) {
+	p := NewDropsolidProvider(
+		&ProviderData{
+			LoginURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/auth"},
+			RedeemURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/token"},
+			ProfileURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/profile"},
+			ValidateURL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/oauth/tokeninfo"},
+			Scope: "profile"})
+	assert.NotEqual(t, nil, p)
+	assert.Equal(t, "Dropsolid", p.Data().ProviderName)
+	assert.Equal(t, "https://example.com/oauth/auth",
+		p.Data().LoginURL.String())
+	assert.Equal(t, "https://example.com/oauth/token",
+		p.Data().RedeemURL.String())
+	assert.Equal(t, "https://example.com/oauth/profile",
+		p.Data().ProfileURL.String())
+	assert.Equal(t, "https://example.com/oauth/tokeninfo",
+		p.Data().ValidateURL.String())
+	assert.Equal(t, "profile", p.Data().Scope)
+}
+
+func TestDropsolidProviderGetEmailAddress(t *testing.T) {
+	b := testDropsolidBackend(`{"account": {"email": "user@example.com"}}`)
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDropsolidProvider(bURL.Host)
+
+	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	email, err := p.GetEmailAddress(session)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "user@example.com", email)
+}
+
+func TestDropsolidProviderGetEmailAddressFailedRequest(t *testing.T) {
+	b := testDropsolidBackend("unused payload")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDropsolidProvider(bURL.Host)
+
+	// We'll trigger a request failure by using an unexpected access
+	// token. Alternatively, we could allow the parsing of the payload as
+	// JSON to fail.
+	session := &sessions.SessionState{AccessToken: "unexpected_access_token"}
+	email, err := p.GetEmailAddress(session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", email)
+}
+
+func TestDropsolidProviderGetEmailAddressEmailNotPresentInPayload(t *testing.T) {
+	b := testDropsolidBackend("{\"foo\": \"bar\"}")
+	defer b.Close()
+
+	bURL, _ := url.Parse(b.URL)
+	p := testDropsolidProvider(bURL.Host)
+
+	session := &sessions.SessionState{AccessToken: "imaginary_access_token"}
+	email, err := p.GetEmailAddress(session)
+	assert.NotEqual(t, nil, err)
+	assert.Equal(t, "", email)
+}

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -5,24 +5,25 @@ import (
 	"github.com/pusher/oauth2_proxy/pkg/logger"
 	"io/ioutil"
 	"net/url"
+
 	oidc "github.com/coreos/go-oidc"
 )
 
 // ProviderData contains information required to configure all implementations
 // of OAuth2 providers
 type ProviderData struct {
-	ProviderName      string
-	ClientID          string
-	ClientSecret      string
-	ClientSecretFile  string
-	LoginURL          *url.URL
-	RedeemURL         *url.URL
-	ProfileURL        *url.URL
-	ProtectedResource *url.URL
-	ValidateURL       *url.URL
-	Scope             string
-	ApprovalPrompt    string
-    JwtBearerVerifiers []*oidc.IDTokenVerifier
+	ProviderName       string
+	ClientID           string
+	ClientSecret       string
+	ClientSecretFile   string
+	LoginURL           *url.URL
+	RedeemURL          *url.URL
+	ProfileURL         *url.URL
+	ProtectedResource  *url.URL
+	ValidateURL        *url.URL
+	Scope              string
+	ApprovalPrompt     string
+	JwtBearerVerifiers []*oidc.IDTokenVerifier
 }
 
 // Data returns the ProviderData

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pusher/oauth2_proxy/pkg/logger"
 	"io/ioutil"
 	"net/url"
+	oidc "github.com/coreos/go-oidc"
 )
 
 // ProviderData contains information required to configure all implementations
@@ -21,6 +22,7 @@ type ProviderData struct {
 	ValidateURL       *url.URL
 	Scope             string
 	ApprovalPrompt    string
+    JwtBearerVerifiers []*oidc.IDTokenVerifier
 }
 
 // Data returns the ProviderData

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -2,17 +2,17 @@ package providers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
+	"github.com/pusher/oauth2_proxy/pkg/encryption"
+	"github.com/pusher/oauth2_proxy/pkg/logger"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
-	"context"
-	"github.com/pusher/oauth2_proxy/pkg/apis/sessions"
-	"github.com/pusher/oauth2_proxy/pkg/encryption"
-    "github.com/pusher/oauth2_proxy/pkg/logger"
 )
 
 // Redeem provides a default implementation of the OAuth2 token redemption process
@@ -137,13 +137,12 @@ func (p *ProviderData) RefreshSessionIfNeeded(s *sessions.SessionState) (bool, e
 	return false, nil
 }
 
-
 // GetJwtSession loads a session based on a JWT token in the authorization header.
 func (p *ProviderData) GetJwtSession(rawBearerToken string) (*sessions.SessionState, error) {
 	ctx := context.Background()
 	var session *sessions.SessionState
 
-	if (p == nil) {
+	if p == nil {
 		return nil, fmt.Errorf("No JwtBearerVerifiers found")
 	}
 

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -44,6 +44,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewNextcloudProvider(p)
 	case "digitalocean":
 		return NewDigitalOceanProvider(p)
+	case "dropsolid":
+		return NewDropsolidProvider(p)		
 	default:
 		return NewGoogleProvider(p)
 	}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -17,6 +17,7 @@ type Provider interface {
 	RefreshSessionIfNeeded(*sessions.SessionState) (bool, error)
 	SessionFromCookie(string, *encryption.Cipher) (*sessions.SessionState, error)
 	CookieForSession(*sessions.SessionState, *encryption.Cipher) (string, error)
+	GetJwtSession(string) (*sessions.SessionState, error)
 }
 
 // New provides a new Provider based on the configured provider string

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -46,7 +46,7 @@ func New(provider string, p *ProviderData) Provider {
 	case "digitalocean":
 		return NewDigitalOceanProvider(p)
 	case "dropsolid":
-		return NewDropsolidProvider(p)		
+		return NewDropsolidProvider(p)
 	default:
 		return NewGoogleProvider(p)
 	}


### PR DESCRIPTION
When forwarding the request to an upstream, it is possible that this upstream has a required authorization header. The proxy currently has no way of setting the basic auth or any other authorization header.

## Description

Adds an option to set the upstream authorization header

## Motivation and Context

The upstream has a hard requirement (Apache Karaf) on a user and couldn't disable this user. We needed to set the Authorization header, eg Basic Auth. I wanted to make it configurable so that also Bearer or any other form is allowed as it is plain text. Use on your own risk. 

## How Has This Been Tested?

We're using this in production now as a fork and it works like magic

## Checklist:

- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
