### PR TITLE
Cleaned up source to make golangci-lint pass

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -13,16 +13,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const CookieSecret = "foobar"
-const ClientID = "bazquux"
-const ClientSecret = "xyzzyplugh"
+const cookieSecret = "foobar"
+const clientID = "bazquux"
+const clientSecret = "xyzzyplugh"
 
 func testOptions() *Options {
 	o := NewOptions()
 	o.Upstreams = append(o.Upstreams, "http://127.0.0.1:8080/")
-	o.CookieSecret = CookieSecret
-	o.ClientID = ClientID
-	o.ClientSecret = ClientSecret
+	o.CookieSecret = cookieSecret
+	o.ClientID = clientID
+	o.ClientSecret = clientSecret
 	o.EmailDomains = []string{"*"}
 	return o
 }
@@ -49,15 +49,15 @@ func TestNewOptions(t *testing.T) {
 
 func TestClientSecretFileOptionFails(t *testing.T) {
 	o := NewOptions()
-	o.CookieSecret = CookieSecret
-	o.ClientID = ClientID
-	o.ClientSecretFile = ClientSecret
+	o.CookieSecret = cookieSecret
+	o.ClientID = clientID
+	o.ClientSecretFile = clientSecret
 	o.EmailDomains = []string{"*"}
 	err := o.Validate()
 	assert.NotEqual(t, nil, err)
 
 	p := o.provider.Data()
-	assert.Equal(t, ClientSecret, p.ClientSecretFile)
+	assert.Equal(t, clientSecret, p.ClientSecretFile)
 	assert.Equal(t, "", p.ClientSecret)
 
 	s, err := p.GetClientSecret()
@@ -79,8 +79,8 @@ func TestClientSecretFileOption(t *testing.T) {
 	defer os.Remove(clientSecretFileName)
 
 	o := NewOptions()
-	o.CookieSecret = CookieSecret
-	o.ClientID = ClientID
+	o.CookieSecret = cookieSecret
+	o.ClientID = clientID
 	o.ClientSecretFile = clientSecretFileName
 	o.EmailDomains = []string{"*"}
 	err = o.Validate()

--- a/options_test.go
+++ b/options_test.go
@@ -13,12 +13,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const CookieSecret = "foobar"
+const ClientID = "bazquux"
+const ClientSecret = "xyzzyplugh"
+
 func testOptions() *Options {
 	o := NewOptions()
 	o.Upstreams = append(o.Upstreams, "http://127.0.0.1:8080/")
-	o.CookieSecret = "foobar"
-	o.ClientID = "bazquux"
-	o.ClientSecret = "xyzzyplugh"
+	o.CookieSecret = CookieSecret
+	o.ClientID = ClientID
+	o.ClientSecret = ClientSecret
 	o.EmailDomains = []string{"*"}
 	return o
 }
@@ -45,15 +49,15 @@ func TestNewOptions(t *testing.T) {
 
 func TestClientSecretFileOptionFails(t *testing.T) {
 	o := NewOptions()
-	o.CookieSecret = "foobar"
-	o.ClientID = "bazquux"
-	o.ClientSecretFile = "xyzzyplugh"
+	o.CookieSecret = CookieSecret
+	o.ClientID = ClientID
+	o.ClientSecretFile = ClientSecret
 	o.EmailDomains = []string{"*"}
 	err := o.Validate()
 	assert.NotEqual(t, nil, err)
 
 	p := o.provider.Data()
-	assert.Equal(t, "xyzzyplugh", p.ClientSecretFile)
+	assert.Equal(t, ClientSecret, p.ClientSecretFile)
 	assert.Equal(t, "", p.ClientSecret)
 
 	s, err := p.GetClientSecret()
@@ -75,8 +79,8 @@ func TestClientSecretFileOption(t *testing.T) {
 	defer os.Remove(clientSecretFileName)
 
 	o := NewOptions()
-	o.CookieSecret = "foobar"
-	o.ClientID = "bazquux"
+	o.CookieSecret = CookieSecret
+	o.ClientID = ClientID
 	o.ClientSecretFile = clientSecretFileName
 	o.EmailDomains = []string{"*"}
 	err = o.Validate()

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -79,7 +79,6 @@ func (p *AzureProvider) Redeem(redirectURL, code string) (s *sessions.SessionSta
 		return
 	}
 
-
 	params := url.Values{}
 	params.Add("redirect_uri", redirectURL)
 	params.Add("client_id", p.ClientID)

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const Post = "POST"
+
 func testAzureProvider(hostname string) *AzureProvider {
 	p := NewAzureProvider(
 		&ProviderData{
@@ -112,9 +114,9 @@ func testAzureBackend(payload string) *httptest.Server {
 
 	return httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			if (r.URL.Path != path || r.URL.RawQuery != query) && r.Method != "POST" {
+			if (r.URL.Path != path || r.URL.RawQuery != query) && r.Method != Post {
 				w.WriteHeader(404)
-			} else if r.Method == "POST" && r.Body != nil {
+			} else if r.Method == Post && r.Body != nil {
 				w.WriteHeader(200)
 				w.Write([]byte(payload))
 			} else if !IsAuthorizedInHeader(r.Header) {

--- a/providers/azure_test.go
+++ b/providers/azure_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const Post = "POST"
-
 func testAzureProvider(hostname string) *AzureProvider {
 	p := NewAzureProvider(
 		&ProviderData{
@@ -114,9 +112,9 @@ func testAzureBackend(payload string) *httptest.Server {
 
 	return httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			if (r.URL.Path != path || r.URL.RawQuery != query) && r.Method != Post {
+			if (r.URL.Path != path || r.URL.RawQuery != query) && r.Method != http.MethodPost {
 				w.WriteHeader(404)
-			} else if r.Method == Post && r.Body != nil {
+			} else if r.Method == http.MethodPost && r.Body != nil {
 				w.WriteHeader(200)
 				w.Write([]byte(payload))
 			} else if !IsAuthorizedInHeader(r.Header) {

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -139,11 +139,10 @@ func (p *OIDCProvider) findVerifiedIDToken(ctx context.Context, token *oauth2.To
 	}
 
 	if rawIDToken, present := getIDToken(); present {
-		verifiedIdToken, err := p.Verifier.Verify(ctx, rawIDToken)
-		return verifiedIdToken, err
-	} else {
-		return nil, nil
+		verifiedIDToken, err := p.Verifier.Verify(ctx, rawIDToken)
+		return verifiedIDToken, err
 	}
+	return nil, nil
 }
 
 func (p *OIDCProvider) createSessionState(token *oauth2.Token, idToken *oidc.IDToken) (*sessions.SessionState, error) {

--- a/providers/oidc_test.go
+++ b/providers/oidc_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"golang.org/x/oauth2"
 
 	"github.com/bmizerany/assert"
@@ -58,7 +59,7 @@ var defaultIDToken idTokenClaims = idTokenClaims{
 	},
 }
 
-type fakeKeySetStub struct {}
+type fakeKeySetStub struct{}
 
 func (fakeKeySetStub) VerifySignature(_ context.Context, jwt string) (payload []byte, err error) {
 	decodeString, err := base64.RawURLEncoding.DecodeString(strings.Split(jwt, ".")[1])
@@ -98,7 +99,7 @@ func newOIDCProvider(serverURL *url.URL) *OIDCProvider {
 
 	p := &OIDCProvider{
 		ProviderData: providerData,
-		Verifier:     oidc.NewVerifier(
+		Verifier: oidc.NewVerifier(
 			"https://issuer.example.com",
 			fakeKeySetStub{},
 			&oidc.Config{ClientID: clientID},
@@ -235,30 +236,30 @@ func TestOIDCProvider_findVerifiedIdToken(t *testing.T) {
 	defer server.Close()
 
 	token := newOauth2Token()
-	signedIdToken, _ := newSignedTestIDToken(defaultIDToken)
-	tokenWithIdToken := token.WithExtra(map[string]interface{}{
-		"id_token": signedIdToken,
+	signedIDToken, _ := newSignedTestIDToken(defaultIDToken)
+	tokenWithIDToken := token.WithExtra(map[string]interface{}{
+		"id_token": signedIDToken,
 	})
 
-	verifiedIdToken, err := provider.findVerifiedIDToken(context.Background(), tokenWithIdToken)
+	verifiedIDToken, err := provider.findVerifiedIDToken(context.Background(), tokenWithIDToken)
 	assert.Equal(t, true, err == nil)
-	assert.Equal(t, true, verifiedIdToken != nil)
-	assert.Equal(t, defaultIDToken.Issuer, verifiedIdToken.Issuer)
-	assert.Equal(t, defaultIDToken.Subject, verifiedIdToken.Subject)
+	assert.Equal(t, true, verifiedIDToken != nil)
+	assert.Equal(t, defaultIDToken.Issuer, verifiedIDToken.Issuer)
+	assert.Equal(t, defaultIDToken.Subject, verifiedIDToken.Subject)
 
 	// When the validation fails the response should be nil
 	defaultIDToken.Id = "this-id-fails-validation"
-	signedIdToken, _ = newSignedTestIDToken(defaultIDToken)
-	tokenWithIdToken = token.WithExtra(map[string]interface{}{
-		"id_token": signedIdToken,
+	signedIDToken, _ = newSignedTestIDToken(defaultIDToken)
+	tokenWithIDToken = token.WithExtra(map[string]interface{}{
+		"id_token": signedIDToken,
 	})
 
-	verifiedIdToken, err = provider.findVerifiedIDToken(context.Background(), tokenWithIdToken)
+	verifiedIDToken, err = provider.findVerifiedIDToken(context.Background(), tokenWithIDToken)
 	assert.Equal(t, errors.New("failed to verify signature: the validation failed for subject [123456789]"), err)
-	assert.Equal(t, true, verifiedIdToken == nil)
+	assert.Equal(t, true, verifiedIDToken == nil)
 
 	// When there is no id token in the oauth token
-	verifiedIdToken, err = provider.findVerifiedIDToken(context.Background(), newOauth2Token())
+	verifiedIDToken, err = provider.findVerifiedIDToken(context.Background(), newOauth2Token())
 	assert.Equal(t, nil, err)
-	assert.Equal(t, true, verifiedIdToken == nil)
+	assert.Equal(t, true, verifiedIDToken == nil)
 }

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -2,9 +2,10 @@ package providers
 
 import (
 	"errors"
-	"github.com/pusher/oauth2_proxy/pkg/logger"
 	"io/ioutil"
 	"net/url"
+
+	"github.com/pusher/oauth2_proxy/pkg/logger"
 )
 
 // ProviderData contains information required to configure all implementations


### PR DESCRIPTION
## Description

Stylistic and whitespace changes to make `golangci-lint` pass.

## Motivation and Context

Out of the box, I couldn't get `make` to work on my system with `master`.

## How Has This Been Tested?

`make` works, and `make test` also works now.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
