### PR TITLE
Fix to work with python 3

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -10,7 +10,7 @@ nav_order: 3
 
 `oauth2_proxy` can be configured via [config file](#config-file), [command line options](#command-line-options) or [environment variables](#environment-variables).
 
-To generate a strong cookie secret use `python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'`
+To generate a strong cookie secret use `python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)).decode())'`
 
 ### Config File
 


### PR DESCRIPTION
## Description
Fix to work with python 3.
This is a documentation fix only.

## Motivation and Context
Python 2.7 went EOL.

## How Has This Been Tested?

```bash
$ python --version
3.8.2

$ python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'
  File "<string>", line 1
    import os,base64; print base64.urlsafe_b64encode(os.urandom(16))
                                 ^
SyntaxError: invalid syntax

$ python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)))'
b'7fQWCy9AzVw5eowTl1bx0Q=='

$ python -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)).decode())'
Djvem9N3Ply7W6F83s6dyQ==

$ python2 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(16)).decode())'
Sn1q-4z0s5c3Kchn2FPUyg==
```

## Checklist:
- [ ] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
