### PR TITLE
Add GitHub Action to tidy stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,5 +13,5 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been inactive for 60 days. If the issue is still relevant, please comment to re-activate the issue. If no action is taken within 7 days, the issue will be marked closed.'
+        stale-issue-message: 'This issue has been inactive for 60 days. If the issue is still relevant please comment to re-activate the issue. If no action is taken within 7 days, the issue will be marked closed.'
         stale-pr-message: 'This pull request has been inactive for 60 days. If the pull request is still relevant, please comment to re-activate the pull request. If no action is taken within 7 days, the pull request will be marked closed.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been inactive for 60 days. If the issue is still relevant, please comment to re-activate the issue. If no action is taken within 7 days, the issue will be marked closed.'
+        stale-pr-message: 'This pull request has been inactive for 60 days. If the pull request is still relevant, please comment to re-activate the pull request. If no action is taken within 7 days, the pull request will be marked closed.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been inactive for 60 days. If the issue is still relevant please comment to re-activate the issue. If no action is taken within 7 days, the issue will be marked closed.'
-        stale-pr-message: 'This pull request has been inactive for 60 days. If the pull request is still relevant, please comment to re-activate the pull request. If no action is taken within 7 days, the pull request will be marked closed.'
+        stale-pr-message: 'This pull request has been inactive for 60 days. If the pull request is still relevant please comment to re-activate the pull request. If no action is taken within 7 days, the pull request will be marked closed.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This will mark issues and pull requests as stale if there has been no activity on them for 60 days.
If no further activity occurs for 7 days, the issue/pr will be closed

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We have a lot of issues and PRs that no one is acting upon, this will either trigger them to be closed (great) or people will say they're still relevant and need review or help

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Hasn't yet! This is my first foray into GitHub actions

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
