### PR TITLE
Fix issue with group validation called on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Changes since v5.0.0
 
+- [#435](https://github.comq/pusher/oauth2_proxy/pull/435) Fix issue with group validation calling google directory API on every HTTP request (@ericofusco)
 - [#400](https://github.com/pusher/oauth2_proxy/pull/400) Add `nsswitch.conf` to Docker image to allow hosts file to work (@luketainton)
 - [#385](https://github.com/pusher/oauth2_proxy/pull/385) Use the `Authorization` header instead of `access_token` for refreshing GitHub Provider sessions (@ibuclaw)
 - [#372](https://github.com/pusher/oauth2_proxy/pull/372) Allow fallback to secondary verified email address in GitHub provider (@dmnemec)

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -900,13 +900,11 @@ func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.R
 		}
 	}
 
-
 	if session != nil && session.Email != "" && !p.Validator(session.Email) {
-			logger.Printf(session.Email, req, logger.AuthFailure, "Invalid authentication via session: removing session %s", session)
-			session = nil
-			saveSession = false
-			clearSession = true
-		}
+		logger.Printf(session.Email, req, logger.AuthFailure, "Invalid authentication via session: removing session %s", session)
+		session = nil
+		saveSession = false
+		clearSession = true
 	}
 
 	if saveSession && session != nil {

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -900,8 +900,8 @@ func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.R
 		}
 	}
 
-	if session != nil && session.Email != "" {
-		if !p.Validator(session.Email) || !p.provider.ValidateGroup(session.Email) {
+
+	if session != nil && session.Email != "" && !p.Validator(session.Email) {
 			logger.Printf(session.Email, req, logger.AuthFailure, "Invalid authentication via session: removing session %s", session)
 			session = nil
 			saveSession = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update reverts change to stop querying Google directory API on every HTTP request.

<!--- Describe your changes in detail -->

Updated with the original logic.

## Motivation and Context

There is no need to run a group validation on every request for any provider. 

With google in particular it causes a ton of HTTP requests to google directory API that can easily hit the maximum daily quota.

Fixes #433 
Caused by #65 

Even with JWT there is no need to verify custom claims for authorization on every request. Tokens are short-lived and this is processed when token is issued or refreshed.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested locally and confirmed google directory API is no longer called on every request. 

I removed the tests related to group validation on JWT because they don't really test anything, it just hardcoded a test group validation method to return false. Tests for group validation on google lives on google_test.go

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
