### PR TITLE
Support prompt in addition to approval-prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Changes since v5.0.0
 
+- [#444](https://github.com/pusher/oauth2_proxy/pull/444) Support prompt in addition to approval-prompt (@holyjak)
 - [#400](https://github.com/pusher/oauth2_proxy/pull/400) Add `nsswitch.conf` to Docker image to allow hosts file to work (@luketainton)
 - [#385](https://github.com/pusher/oauth2_proxy/pull/385) Use the `Authorization` header instead of `access_token` for refreshing GitHub Provider sessions (@ibuclaw)
 - [#372](https://github.com/pusher/oauth2_proxy/pull/372) Allow fallback to secondary verified email address in GitHub provider (@dmnemec)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -78,6 +78,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 | `-pass-host-header` | bool | pass the request Host Header to upstream | true |
 | `-pass-user-headers` | bool | pass X-Forwarded-User, X-Forwarded-Email and X-Forwarded-Preferred-Username information to upstream | true |
 | `-profile-url` | string | Profile access endpoint | |
+| `-prompt` | string | [OIDC prompt](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest); if present, `approval-prompt` is ignored | `""` |
 | `-provider` | string | OAuth provider | google |
 | `-provider-display-name` | string | Override the provider's name with the given string; used for the sign-in page | (depends on provider) |
 | `-ping-path` | string | the ping endpoint that can be used for basic health checks | `"/ping"` |

--- a/main.go
+++ b/main.go
@@ -132,6 +132,7 @@ func main() {
 	flagSet.String("resource", "", "The resource that is protected (Azure AD only)")
 	flagSet.String("validate-url", "", "Access token validation endpoint")
 	flagSet.String("scope", "", "OAuth scope specification")
+	flagSet.String("prompt", "", "OIDC prompt")
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")

--- a/options.go
+++ b/options.go
@@ -101,7 +101,8 @@ type Options struct {
 	ProtectedResource                string `flag:"resource" cfg:"resource" env:"OAUTH2_PROXY_RESOURCE"`
 	ValidateURL                      string `flag:"validate-url" cfg:"validate_url" env:"OAUTH2_PROXY_VALIDATE_URL"`
 	Scope                            string `flag:"scope" cfg:"scope" env:"OAUTH2_PROXY_SCOPE"`
-	ApprovalPrompt                   string `flag:"approval-prompt" cfg:"approval_prompt" env:"OAUTH2_PROXY_APPROVAL_PROMPT"`
+	Prompt                           string `flag:"prompt" cfg:"prompt" env:"OAUTH2_PROXY_PROMPT"`
+	ApprovalPrompt                   string `flag:"approval-prompt" cfg:"approval_prompt" env:"OAUTH2_PROXY_APPROVAL_PROMPT"` // Deprecated by OIDC 1.0
 
 	// Configuration values for logging
 	LoggingFilename       string `flag:"logging-filename" cfg:"logging_filename" env:"OAUTH2_PROXY_LOGGING_FILENAME"`
@@ -171,6 +172,7 @@ func NewOptions() *Options {
 		SetAuthorization:                 false,
 		PassAuthorization:                false,
 		PreferEmailToUser:                false,
+		Prompt:                           "", // Change to "login" when ApprovalPrompt officially deprecated
 		ApprovalPrompt:                   "force",
 		InsecureOIDCAllowUnverifiedEmail: false,
 		SkipOIDCDiscovery:                false,
@@ -411,6 +413,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		ClientID:         o.ClientID,
 		ClientSecret:     o.ClientSecret,
 		ClientSecretFile: o.ClientSecretFile,
+		Prompt:           o.Prompt,
 		ApprovalPrompt:   o.ApprovalPrompt,
 	}
 	p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -20,6 +20,7 @@ type ProviderData struct {
 	ProtectedResource *url.URL
 	ValidateURL       *url.URL
 	Scope             string
+	Prompt            string
 	ApprovalPrompt    string
 }
 

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -90,7 +90,11 @@ func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
 	a = *p.LoginURL
 	params, _ := url.ParseQuery(a.RawQuery)
 	params.Set("redirect_uri", redirectURI)
-	params.Set("approval_prompt", p.ApprovalPrompt)
+	if p.Prompt != "" {
+		params.Set("prompt", p.Prompt)
+	} else { // Legacy variant of the prompt param:
+		params.Set("approval_prompt", p.ApprovalPrompt)
+	}
 	params.Add("scope", p.Scope)
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")


### PR DESCRIPTION
Fix #380 - add the config option `prompt` in addition to the legacy `approval-prompt`.

## Description

Add and use a new config option. If present, ignored the old `approval-prompt` option.
To be able to see whether `prompt` has been provided, I default it to `""` (thus I know that if `p.Prompt != ""` the user has explicitly provided it and it is safe to not be backwards-compatible and to ignore the old `approval-prompt`).

Ideally, we would default `prompt` to `"login"` (or perhaps `"consent"`?) but we would then have no way of knowing whether to send `prompt` or `approval-prompt`.

Alternatively, we could default it to `"login"` and simply send both `prompt` (ignored by older providers) and `approval-prompt` (ignored by newer providers). However this assumes that all providers are sane and only take one of these options and do not error or do something weird when provided with both. Can we risk it?

## Motivation and Context

See #380. I have not been able to track down where `approval-prompt` originates from. OIDC 1.0 only mentions `prompt`. I have not been able to find out anything related in the oauth 2 core spec. (Even https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml only mentions `prompt`.)

## How Has This Been Tested?

Running the proxy, accessing it with an unauthenticated users, and verifying the redirect URL. I have tested these cases:

| Config                  | Redirect contained      | Why?                                    |
| ----------------------- | ----------------------- | --------------------------------------- |
| none                    | `approval_prompt=force` | Same default as before                  |
| `-prompt login`         | `prompt=login`          | -prompt works, replaces approval_prompt |
| `-approval-prompt xxxx` | approval_prompt=xxxx    | -approval-prompt works                  |


## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
