### PR TITLE
Fix #381, expose acr_values to all providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Changes since v5.0.0
 
+- [#445](https://github.com/pusher/oauth2_proxy/pull/445) Expose `acr_values` to all providers (@holyjak)
 - [#419](https://github.com/pusher/oauth2_proxy/pull/419) Support Go 1.14, upgrade dependencies, upgrade golangci-lint to 1.23.6 (@johejo)
 - [#444](https://github.com/pusher/oauth2_proxy/pull/444) Support prompt in addition to approval-prompt (@holyjak)
 - [#435](https://github.com/pusher/oauth2_proxy/pull/435) Fix issue with group validation calling google directory API on every HTTP request (@ericofusco)

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -22,7 +22,7 @@ An example [oauth2_proxy.cfg]({{ site.gitweb }}/contrib/oauth2_proxy.cfg.example
 
 | Option | Type | Description | Default |
 | ------ | ---- | ----------- | ------- |
-| `-acr-values` | string | optional, used by login.gov | `"http://idmanagement.gov/ns/assurance/loa/1"` |
+| `-acr-values` | string | optional, see [docs](https://openid.net/specs/openid-connect-eap-acr-values-1_0.html#acrValues) | `""` |
 | `-approval-prompt` | string | OAuth approval_prompt | `"force"` |
 | `-auth-logging` | bool | Log authentication attempts | true |
 | `-auth-logging-format` | string | Template for authentication log lines | see [Logging Configuration](#logging-configuration) |

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 	flagSet.String("approval-prompt", "force", "OAuth approval_prompt")
 
 	flagSet.String("signature-key", "", "GAP-Signature request signature key (algorithm:secretkey)")
-	flagSet.String("acr-values", "http://idmanagement.gov/ns/assurance/loa/1", "acr values string:  optional, used by login.gov")
+	flagSet.String("acr-values", "", "acr values string:  optional")
 	flagSet.String("jwt-key", "", "private key in PEM format used to sign JWT, so that you can say something like -jwt-key=\"${OAUTH2_PROXY_JWT_KEY}\": required by login.gov")
 	flagSet.String("jwt-key-file", "", "path to the private key file in PEM format used to sign the JWT so that you can say something like -jwt-key-file=/etc/ssl/private/jwt_signing_key.pem: required by login.gov")
 	flagSet.String("pubjwk-url", "", "JWK pubkey access endpoint: required by login.gov")

--- a/options.go
+++ b/options.go
@@ -415,6 +415,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		ClientSecretFile: o.ClientSecretFile,
 		Prompt:           o.Prompt,
 		ApprovalPrompt:   o.ApprovalPrompt,
+		AcrValues:        o.AcrValues,
 	}
 	p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
 	p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)
@@ -473,7 +474,6 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 			}
 		}
 	case *providers.LoginGovProvider:
-		p.AcrValues = o.AcrValues
 		p.PubJWKURL, msgs = parseURL(o.PubJWKURL, "pubjwk", msgs)
 
 		// JWT key can be supplied via env variable or file in the filesystem, but not both.

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -24,7 +24,6 @@ type LoginGovProvider struct {
 	// TODO (@timothy-spencer): Ideally, the nonce would be in the session state, but the session state
 	// is created only upon code redemption, not during the auth, when this must be supplied.
 	Nonce     string
-	AcrValues string
 	JWTKey    *rsa.PrivateKey
 	PubJWKURL *url.URL
 }
@@ -270,7 +269,11 @@ func (p *LoginGovProvider) GetLoginURL(redirectURI, state string) string {
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")
 	params.Add("state", state)
-	params.Add("acr_values", p.AcrValues)
+	acr := p.AcrValues
+	if acr == "" {
+		acr = "http://idmanagement.gov/ns/assurance/loa/1"
+	}
+	params.Add("acr_values", acr)
 	params.Add("nonce", p.Nonce)
 	a.RawQuery = params.Encode()
 	return a.String()

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -12,17 +12,20 @@ import (
 // of OAuth2 providers
 type ProviderData struct {
 	ProviderName      string
-	ClientID          string
-	ClientSecret      string
-	ClientSecretFile  string
 	LoginURL          *url.URL
 	RedeemURL         *url.URL
 	ProfileURL        *url.URL
 	ProtectedResource *url.URL
 	ValidateURL       *url.URL
-	Scope             string
-	Prompt            string
-	ApprovalPrompt    string
+	// Auth request params & related, see
+	//https://openid.net/specs/openid-connect-basic-1_0.html#rfc.section.2.1.1.1
+	AcrValues        string
+	ApprovalPrompt   string // NOTE: Renamed to "prompt" in OAuth2
+	ClientID         string
+	ClientSecret     string
+	ClientSecretFile string
+	Scope            string
+	Prompt           string
 }
 
 // Data returns the ProviderData

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -90,6 +90,7 @@ func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
 	a = *p.LoginURL
 	params, _ := url.ParseQuery(a.RawQuery)
 	params.Set("redirect_uri", redirectURI)
+	params.Add("acr_values", p.AcrValues)
 	if p.Prompt != "" {
 		params.Set("prompt", p.Prompt)
 	} else { // Legacy variant of the prompt param:


### PR DESCRIPTION
Move the `acr_values` option from the login.gov provider to the base provider data.

## Description

Additionally, we default it to "" with the exception of login.gov, where we set it to the old default value for backwards compatibility.

## Motivation and Context

See #381 

## How Has This Been Tested?

I have run the proxy with an OIDC provider and specified `-acr-values` and verified that it has been included in the login URL.

I have _not_ verified that login.gov works as before and that it does still default to the old default URL, as I do not have access to it.

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
