### PR TITLE
Bitbucket Auth Provider docs

### DIFF
--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -23,6 +23,7 @@ Valid providers are :
 - [login.gov](#logingov-provider)
 - [Nextcloud](#nextcloud-provider)
 - [DigitalOcean](#digitalocean-auth-provider)
+- [Bitbucket](#bitbucket-auth-provider)
 
 The provider can be selected using the `provider` configuration value.
 
@@ -341,6 +342,27 @@ To use the provider, pass the following options:
 ```
 
  Alternatively, set the equivalent options in the config file. The redirect URL defaults to `https://<requested host header>/oauth2/callback`. If you need to change it, you can use the `--redirect-url` command-line option.
+
+### Bitbucket Auth Provider
+
+1. [Add a new OAuth consumer](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html)
+    * In "Callback URL" use `https://oauth-proxy/oauth2/callback`, substituting `oauth2-proxy` with the actual hostname that oauth2_proxy is running on.
+    * In Permissions section select:
+        * Account -> Email
+        * Team membership -> Read
+        * Repositories -> Read
+2. Note the Client ID and Client Secret.
+
+To use the provider, pass the following options:
+
+```
+   --provider=bitbucket
+   --client-id=<Client ID>
+   --client-secret=<Client Secret>
+```
+
+The default configuration allows everyone with Bitbucket account to authenticate. To restrict the access to the team members use additional configuration option: `--bitbucket-team=<Team name>`. To restrict the access to only these users who has access to one selected repository use `--bitbucket-repository=<Repository name>`.
+
 
 ## Email Authentication
 

--- a/docs/2_auth.md
+++ b/docs/2_auth.md
@@ -346,7 +346,7 @@ To use the provider, pass the following options:
 ### Bitbucket Auth Provider
 
 1. [Add a new OAuth consumer](https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html)
-    * In "Callback URL" use `https://oauth-proxy/oauth2/callback`, substituting `oauth2-proxy` with the actual hostname that oauth2_proxy is running on.
+    * In "Callback URL" use `https://<oauth2-proxy>/oauth2/callback`, substituting `<oauth2-proxy>` with the actual hostname that oauth2_proxy is running on.
     * In Permissions section select:
         * Account -> Email
         * Team membership -> Read


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the documentation for Bitbucket Authentication (implemented in https://github.com/pusher/oauth2_proxy/pull/201)

## Motivation and Context

By looking at the documentation itself it's not clear if Bitbucket is supported or not. I also struggled to select proper scope for the App. Hopefully this short documentation section will save others time.

## How Has This Been Tested?

Reviewed with `make serve`

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
