### PR TITLE
Fix http.Cookie SameSite is not copied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Changes since v5.0.0
 
+- [#450](https://github.com/pusher/oauth2_proxy/pull/450) Fix http.Cookie SameSite is not copied (@johejo)
 - [#445](https://github.com/pusher/oauth2_proxy/pull/445) Expose `acr_values` to all providers (@holyjak)
 - [#419](https://github.com/pusher/oauth2_proxy/pull/419) Support Go 1.14, upgrade dependencies, upgrade golangci-lint to 1.23.6 (@johejo)
 - [#444](https://github.com/pusher/oauth2_proxy/pull/444) Support prompt in addition to approval-prompt (@holyjak)

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -207,5 +207,6 @@ func copyCookie(c *http.Cookie) *http.Cookie {
 		HttpOnly:   c.HttpOnly,
 		Raw:        c.Raw,
 		Unparsed:   c.Unparsed,
+		SameSite:   c.SameSite,
 	}
 }

--- a/pkg/sessions/cookie/session_store_test.go
+++ b/pkg/sessions/cookie/session_store_test.go
@@ -1,0 +1,30 @@
+package cookie
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_copyCookie(t *testing.T) {
+	expire, _ := time.Parse(time.RFC3339, "2020-03-17T00:00:00Z")
+	c := &http.Cookie{
+		Name:       "name",
+		Value:      "value",
+		Path:       "/path",
+		Domain:     "x.y.z",
+		Expires:    expire,
+		RawExpires: "rawExpire",
+		MaxAge:     1,
+		Secure:     true,
+		HttpOnly:   true,
+		Raw:        "raw",
+		Unparsed:   []string{"unparsed"},
+		SameSite:   http.SameSiteLaxMode,
+	}
+
+	got := copyCookie(c)
+	assert.Equal(t, c, got)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed a bug that http.Cookie SameSite was not copied.

<!--- Describe your changes in detail -->

## Motivation and Context

Even if `--cookie-samesite=lax` is specified in an environment where cookies are divided because it's large, the SameSite attribute was not set in the browser developer tool.

I found this bug when I dealing with Chrome 80 SameSite change.
https://www.chromium.org/updates/same-site

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added test for `copyCookie`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
